### PR TITLE
Fix mongoose model doc reference types

### DIFF
--- a/backend/src/models/encounter.model.ts
+++ b/backend/src/models/encounter.model.ts
@@ -1,17 +1,17 @@
-import { Schema, model } from 'mongoose';
+import mongoose, { Schema, model } from 'mongoose';
 
 export interface EncounterModel {
   date: Date,
   location: string,
   description: string,
-  persons: [Schema.Types.ObjectId]
+  persons: mongoose.Types.ObjectId[]
 }
 
 const schema = new Schema<EncounterModel>({
   date: { type: Date, default: Date.now },
   location: { type: String, required: false },
   description: { type: String, required: true },
-  persons: { type: [Schema.Types.ObjectId], required: true },
+  persons: { type: [mongoose.Types.ObjectId], required: true },
 });
 
 export default model<EncounterModel>('Encounter', schema);

--- a/backend/src/models/person.model.ts
+++ b/backend/src/models/person.model.ts
@@ -1,7 +1,7 @@
 /**
  * Model defines a datatype's schema (kinda like class)
  */
-import { Schema, model } from 'mongoose';
+import mongoose, { Schema, model } from 'mongoose';
 
 export interface PersonModel {
   first_name: string,
@@ -11,7 +11,7 @@ export interface PersonModel {
   organisation: string,
   time_added: Date,
   how_we_met: string,
-  encounters: [Schema.Types.ObjectId]
+  encounters: mongoose.Types.ObjectId[]
 }
 
 const schema = new Schema<PersonModel>({
@@ -20,9 +20,9 @@ const schema = new Schema<PersonModel>({
   birthday: { type: Date, required: false },
   interests: { type: [String], required: false },
   organisation: { type: String, required: false },
-  time_added: { type: Date, required: true },
+  time_added: { type: Date, default: Date.now, required: true },
   how_we_met: { type: String, required: false },
-  encounters: { type: [Schema.Types.ObjectId], required: false },
+  encounters: { type: [mongoose.Types.ObjectId], required: false },
 });
 
 export default model<PersonModel>('Person', schema);

--- a/backend/src/models/user.model.ts
+++ b/backend/src/models/user.model.ts
@@ -1,19 +1,19 @@
-import { Schema, model } from 'mongoose';
+import mongoose, { Schema, model } from 'mongoose';
 
 export interface UserModel {
-    auth_id: string,
-    first_name: string,
-    last_name: string,
-    persons: [Schema.Types.ObjectId]
-    encounters: [Schema.Types.ObjectId]
+  auth_id: string,
+  first_name: string,
+  last_name: string,
+  persons: mongoose.Types.ObjectId[]
+  encounters: mongoose.Types.ObjectId[]
 }
 
 const schema = new Schema<UserModel>({
   auth_id: { type: String, required: true },
   first_name: { type: String, required: true },
   last_name: { type: String, required: true },
-  persons: { type: [Schema.Types.ObjectId] },
-  encounters: { type: [Schema.Types.ObjectId] },
+  persons: { type: [mongoose.Types.ObjectId] },
+  encounters: { type: [mongoose.Types.ObjectId] },
 });
 
 export default model<UserModel>('User', schema);


### PR DESCRIPTION
Addresses #106.
Changes the doc reference types in mongoose models to `mongoose.Types.ObjectId[]` from `[Schema.Types.ObjectId]`