### PR TITLE
Fixes address in use error for multiple test suites

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,20 +5,13 @@ import routes from './routes';
 import config from './utils/config';
 import logger from './utils/logger';
 import middleware from './utils/middleware';
+import app from './server';
 
 if (process.env.NODE_ENV !== 'test') {
   connect(config.MONGODB_URI)
     .then(() => logger.info('connected to MongoDB'))
     .catch((err) => logger.error('error connecting to mongodb:', err.message));
 }
-
-const app = express();
-
-app.use(express.urlencoded({ extended: false }));
-app.use(cors());
-app.use(express.json());
-app.use('/api', routes);
-app.use(middleware.errorHandler);
 
 app.listen(config.PORT, () => logger.info(`App server listening on port ${config.PORT}!`));
 

--- a/backend/src/routes/__test__/encounter.route.test.ts
+++ b/backend/src/routes/__test__/encounter.route.test.ts
@@ -1,7 +1,7 @@
 import httpStatus from 'http-status';
 import databaseOperations from '../../utils/test/db-handler';
 import { EncounterModel } from 'src/models/encounter.model';
-import app from '../../index';
+import app from '../../server';
 
 const supertest = require('supertest');
 

--- a/backend/src/routes/__test__/person.route.test.ts
+++ b/backend/src/routes/__test__/person.route.test.ts
@@ -1,7 +1,7 @@
 import httpStatus from 'http-status';
 import databaseOperations from '../../utils/test/db-handler';
 import { PersonModel } from '../../models/person.model';
-import app from '../../index';
+import app from '../../server';
 
 const supertest = require('supertest');
 

--- a/backend/src/routes/__test__/user.route.test.ts
+++ b/backend/src/routes/__test__/user.route.test.ts
@@ -1,7 +1,7 @@
 import httpStatus from 'http-status';
 import databaseOperations from '../../utils/test/db-handler';
 import { UserModel } from 'src/models/user.model';
-import app from '../../index';
+import app from '../../server';
 
 const supertest = require('supertest');
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+import cors from 'cors';
+import routes from './routes';
+import middleware from './utils/middleware';
+
+const app = express();
+
+app.use(express.urlencoded({ extended: false }));
+app.use(cors());
+app.use(express.json());
+app.use('/api', routes);
+app.use(middleware.errorHandler);
+
+export default app;


### PR DESCRIPTION
Server attempted to listen to the same port multiple times when running test suites. Express app is abstracted into another file and test suites uses the app without listening to port.

Fix for #118 

![image](https://user-images.githubusercontent.com/90881342/158000339-0778e152-60ca-47b6-80bf-bad5a4a9feff.png)
![image](https://user-images.githubusercontent.com/90881342/158000350-306d641f-2721-478f-9d90-4ca2e786bad1.png)
![image](https://user-images.githubusercontent.com/90881342/158000355-9bf5f622-5371-4066-8d6f-e4c29b7a4d45.png)

Runs all test suites without "address already in use" error.
