### PR TITLE
Added Firebase Authorization to middleware

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,18 +1,16 @@
-import express from 'express';
-import { connect } from 'mongoose';
-import cors from 'cors';
-import routes from './routes';
-import config from './utils/config';
-import logger from './utils/logger';
-import middleware from './utils/middleware';
-import app from './server';
+import { connect } from "mongoose";
+import config from "./utils/config";
+import logger from "./utils/logger";
+import app from "./server";
 
-if (process.env.NODE_ENV !== 'test') {
+if (process.env.NODE_ENV !== "test") {
   connect(config.MONGODB_URI)
-    .then(() => logger.info('connected to MongoDB'))
-    .catch((err) => logger.error('error connecting to mongodb:', err.message));
+    .then(() => logger.info("connected to MongoDB"))
+    .catch((err) => logger.error("error connecting to mongodb:", err.message));
 }
 
-app.listen(config.PORT, () => logger.info(`App server listening on port ${config.PORT}!`));
+app.listen(config.PORT, () =>
+  logger.info(`App server listening on port ${config.PORT}!`)
+);
 
 export default app;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,14 +1,15 @@
-import express from 'express';
-import cors from 'cors';
-import routes from './routes';
-import middleware from './utils/middleware';
+import express from "express";
+import cors from "cors";
+import routes from "./routes";
+import middleware from "./utils/middleware";
 
 const app = express();
 
 app.use(express.urlencoded({ extended: false }));
 app.use(cors());
 app.use(express.json());
-app.use('/api', routes);
+app.use(middleware.authHandler);
+app.use("/api", routes);
 app.use(middleware.errorHandler);
 
 export default app;

--- a/backend/src/utils/middleware.ts
+++ b/backend/src/utils/middleware.ts
@@ -1,20 +1,44 @@
-import { NextFunction, Request, Response } from 'express';
-import httpStatus from 'http-status';
-import logger from './logger';
+import { NextFunction, Request, Response } from "express";
+import httpStatus from "http-status";
+import logger from "./logger";
+import FirebaseAdmin from "../firebase-configs/firebase-config";
 
 const errorHandler = (
   error: any,
   req: Request,
   res: Response,
-  next: NextFunction,
+  next: NextFunction
 ) => {
   logger.error(error.message);
-  if (error.name === 'ValidationError') {
+  if (error.name === "ValidationError") {
     return res.status(httpStatus.BAD_REQUEST).json({ error: error.message });
   }
   next(error);
+  return;
+};
+
+const authHandler = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.headers.authorization) {
+    logger.info("No Authorization Header - authHandler");
+    res.status(httpStatus.UNAUTHORIZED).end();
+  } else {
+    const idToken = req.headers.authorization;
+
+    FirebaseAdmin.auth()
+      .verifyIdToken(idToken)
+      .then((decodedToken) => {
+        req.headers.authorization = decodedToken;
+        logger.info("Request Authorized - authHandler");
+        next();
+      })
+      .catch((error) => {
+        logger.info("Caught Unauthorized Request - authHandler");
+        res.status(httpStatus.UNAUTHORIZED).end();
+      });
+  }
 };
 
 export default {
   errorHandler,
+  authHandler,
 };


### PR DESCRIPTION
Fixes #121 

Created a function in `middleware.ts` that authenticates the incoming request using Firebase before sending it off to other API routes. The decodedToken is set as the `req.headers.authorization` in the incoming request to the other API routes. The `auth_id` for the users can be retrieved from the decodedToken object. 

This PR was worked on by @AdamAWiener @sdiv877 @jimwang6012 