### PR TITLE
Add auth and query params to GET persons/

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# firebase-config
+forgettable_service_account.json

--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -31,7 +31,7 @@ export const getAllPeople = async (
   logger.info('GET /persons request from frontend');
 
   try {
-    const people = await personService.getPeople();
+    const people = await personService.getPeople(req.query);
     res.status(httpStatus.OK).json(people);
   } catch (e) {
     next(e);

--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -3,6 +3,7 @@
  */
 import { Request, Response, NextFunction } from 'express';
 import httpStatus from 'http-status';
+import userService from '../services/user.service';
 import personService from '../services/person.service';
 import logger from '../utils/logger';
 
@@ -30,9 +31,20 @@ export const getAllPeople = async (
 ): Promise<void> => {
   logger.info('GET /persons request from frontend');
 
+  const auth_id = req.headers.authorization?.["user_id"];
+  const user = await userService.getUserByAuthId(auth_id);
+
   try {
-    const people = await personService.getPeople(req.query);
-    res.status(httpStatus.OK).json(people);
+    if (!user) {
+      res.status(httpStatus.NOT_FOUND).end();
+    } else {
+      if (!user.persons.length) {
+        res.status(httpStatus.NO_CONTENT).end();
+      } else {
+        const foundUserPersons = await personService.getPeople(req.query, user.persons);
+        res.status(httpStatus.OK).json(foundUserPersons).end();
+      }
+    }
   } catch (e) {
     next(e);
   }

--- a/backend/src/services/person.service.ts
+++ b/backend/src/services/person.service.ts
@@ -1,6 +1,7 @@
 /**
  * Service contains database operations
  */
+import mongoose from 'mongoose';
 import Person, { PersonModel } from '../models/person.model';
 import logger from '../utils/logger';
 
@@ -14,15 +15,26 @@ const createPerson = async (personDetails: PersonModel) => {
  * Note that .clone is necessary to avoid error 'Query was already executed'
  * Refer to section 'Duplicate Query Execution under https://mongoosejs.com/docs/migrating_to_6.html
  */
-const getPeople = async (queryParams: any) => {
-  if (Object.keys(queryParams).length === 0) {
-    return await Person.find(() => true).clone();
-  } else {
+const getPeople = async (queryParams: any, userPersons: mongoose.Types.ObjectId[]) => {
+  // Log query params if received
+  if (Object.keys(queryParams).length > 0) {
     logger.info('Query params received:');
     logger.info(queryParams);
-
-    return await Person.find({...queryParams}, () => true).clone();
   }
+
+  // Get all persons from the db that belong to the user
+  let foundUserPersons =  await Person.find({ _id: { $in: userPersons } });
+
+  // Filter them by query params (only works with exact strings)
+  let filteredPersons = foundUserPersons.filter(function(person) {
+    for (var key in queryParams) {
+      if (person[key] === undefined || person[key] != queryParams[key])
+        return false;
+    }
+    return true; 
+  });
+
+  return filteredPersons;
 };
 
 const personService = {

--- a/backend/src/services/person.service.ts
+++ b/backend/src/services/person.service.ts
@@ -2,6 +2,7 @@
  * Service contains database operations
  */
 import Person, { PersonModel } from '../models/person.model';
+import logger from '../utils/logger';
 
 const createPerson = async (personDetails: PersonModel) => {
   const person = new Person(personDetails);
@@ -13,7 +14,17 @@ const createPerson = async (personDetails: PersonModel) => {
  * Note that .clone is necessary to avoid error 'Query was already executed'
  * Refer to section 'Duplicate Query Execution under https://mongoosejs.com/docs/migrating_to_6.html
  */
-const getPeople = async () => Person.find(() => true).clone();
+const getPeople = async (queryParams: any) => {
+  if (Object.keys(queryParams).length === 0) {
+    return await Person.find(() => true).clone();
+  } else {
+    logger.info('Query params received:');
+    logger.info(queryParams);
+
+    return await Person.find({...queryParams}, () => true).clone();
+  }
+};
+
 const personService = {
   createPerson,
   getPeople,


### PR DESCRIPTION
Addresses #93:
* Added authorisation checks to GET persons
* Added query params to GET persons (any single string fields in the `Person` model may be queried and do not need to be exact strings)

Manual Postman Tests:
* Only persons that belong to the `User` found through the `auth_id` are returned (`200 OK`) ✔️ 
* If a `User` is not found returns `404 Not Found` ✔️ 
* If a `User` has no `persons` returns `204 No Content` ✔️ 
* Query params for fields that are single strings are applied ✔️ 
    * `full_name`
    * `gender`
    * `location`
    * `how_we_met`
    * `organisation`
 * If a query param is empty it is ignored ✔️

To be fixed later:
* Add real unit tests to replace manual tests
* Add querying by Dates and string arrays using Algolia