### PR TITLE
Add auth to POST persons/

### DIFF
--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -15,7 +15,7 @@ export const createPerson: POST = async (
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
-  logger.info('POST /persons/create request from frontend');
+  logger.info('POST /persons request from frontend');
   const auth_id = req.headers.authorization?.["user_id"];
 
   try {

--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -25,7 +25,7 @@ export const createPerson: POST = async (
   }
 };
 
-export const getPersonWithId = async(
+export const getPersonWithId = async (
   req: Request,
   res: Response,
   next: NextFunction,
@@ -33,22 +33,28 @@ export const getPersonWithId = async(
   logger.info('GET /persons/:id request from frontend');
 
   const auth_id = req.headers.authorization?.["user_id"];
-  const user = await userService.getUserByAuthId(auth_id);
 
-  if (!user) {
-    res.status(httpStatus.NOT_FOUND).end();
-  } else {
-    // If the person belongs to this user, find it
-    let person;
-    if (user.persons.includes(new mongoose.Types.ObjectId(req.params.id))) {
-      person = await personService.getPersonWithId(req.params.id);
-    }
+  try {
+    const user = await userService.getUserByAuthId(auth_id);
 
-    if (!person) {
+    if (!user) {
       res.status(httpStatus.NOT_FOUND).end();
     } else {
-      res.status(httpStatus.OK).json(person).end();
+      // If the person belongs to this user, find it
+      let person;
+      if (user.persons.includes(new mongoose.Types.ObjectId(req.params.id))) {
+        person = await personService.getPersonWithId(req.params.id);
+      }
+
+      if (!person) {
+        res.status(httpStatus.NOT_FOUND).end();
+      } else {
+        res.status(httpStatus.OK).json(person).end();
+      }
     }
+  }
+  catch (e) {
+    next(e);
   }
 }
 
@@ -60,9 +66,10 @@ export const getAllPeople = async (
   logger.info('GET /persons request from frontend');
 
   const auth_id = req.headers.authorization?.["user_id"];
-  const user = await userService.getUserByAuthId(auth_id);
 
   try {
+    const user = await userService.getUserByAuthId(auth_id);
+
     if (!user) {
       res.status(httpStatus.NOT_FOUND).end();
     } else {

--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -16,11 +16,32 @@ export const createPerson: POST = async (
   next: NextFunction,
 ): Promise<void> => {
   logger.info('POST /persons/create request from frontend');
+  const auth_id = req.headers.authorization?.["user_id"];
 
   try {
-    const person = await personService.createPerson(req.body);
-    res.status(httpStatus.CREATED).send(person);
-  } catch (e) {
+    let user = await userService.getUserByAuthId(auth_id);
+
+    if (!user) {
+      res.status(httpStatus.NOT_FOUND).end();
+    } else {
+      // Create a new person with the provided information
+      const createdPerson = await personService.createPerson(req.body);
+
+      if (!createdPerson) {
+        res.status(httpStatus.BAD_REQUEST).end();
+      } else {
+        // Add a reference to the created person to the user
+        user = await userService.addPersonId(user.auth_id, createdPerson._id)
+        // If user doesn't contain reference to new person return Conflict
+        if (!user?.persons.includes(new mongoose.Types.ObjectId(createdPerson._id))) {
+          res.status(httpStatus.CONFLICT).end();
+        } else {
+          res.status(httpStatus.CREATED).json(createdPerson).end();
+        }
+      }
+    }
+  }
+  catch (e) {
     next(e);
   }
 };
@@ -31,7 +52,6 @@ export const getPersonWithId = async (
   next: NextFunction,
 ): Promise<void> => {
   logger.info('GET /persons/:id request from frontend');
-
   const auth_id = req.headers.authorization?.["user_id"];
 
   try {
@@ -64,7 +84,6 @@ export const getAllPeople = async (
   next: NextFunction,
 ): Promise<void> => {
   logger.info('GET /persons request from frontend');
-
   const auth_id = req.headers.authorization?.["user_id"];
 
   try {

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -19,9 +19,18 @@ export const getUserByAuthId = async (uid) => {
   return user;
 };
 
+export const addPersonId = async(uid, pid) => {
+  const updatedUser = await User.findOneAndUpdate(
+    { auth_id: uid }, 
+    { $push: { persons: pid }},
+    { returnOriginal: false })
+  return updatedUser;
+}
+
 const userService = {
   createUser,
   getUserByAuthId,
+  addPersonId
 };
 
 export default userService;


### PR DESCRIPTION
Addresses #82:
* Adds auth checks to POST persons/ endpoint
* Adds a missing try catch to the GET persons/:id endpoint

Manual Postman tests:
* If a valid person is provided and a reference is successfully added to the `User`, return `201 Created` ✔️
* If a valid person is provided and a reference is NOT added to the `User`, return `409 Conflict` ✔️
* If an invalid person is provided return `400 Bad Request` ✔️
* If `User` is not found return `404 Not Found` ✔️

To be fixed later:
* Add real unit tests to replace manual tests