### PR TITLE
Update person drawer to have option to be displayed as static drawer

### DIFF
--- a/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.js
+++ b/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.js
@@ -41,9 +41,11 @@ const PersonDrawer = (props) => {
               height: '200px',
               width: '200px',
               backgroundColor:
-                getComputedStyle(document.body).getPropertyValue('--prmry'),
+                getComputedStyle(document.body)
+                    .getPropertyValue('--prmry'),
               fontSize:
-                getComputedStyle(document.body).getPropertyValue('--text-xxlarge')
+                getComputedStyle(document.body)
+                    .getPropertyValue('--text-xxlarge')
               ,
             }}
             src={props.img}
@@ -56,7 +58,11 @@ const PersonDrawer = (props) => {
               First met {getFirstMetTimeString(props.firstMet)}
             </h2>
           </div>
-          <div className={props.staticDrawer ? classes.InfoContent : classNames(classes.InfoContent, classes.InfoContentPadding)}>
+          <div
+            className={props.staticDrawer ?
+          classes.InfoContent :
+          classNames(classes.InfoContent, classes.InfoContentPadding)}
+          >
             <p data-testid="age-element">
               {'Age: '}
               {props.birthday?
@@ -131,7 +137,13 @@ const PersonDrawer = (props) => {
                  })}
                </span> :unknownDetail}
             </p>
-            <CustomButton btnText="Edit" className={classes.EditButton} textStyle={classes.ButtonText}/>
+            {props.staticDrawer &&
+            <CustomButton
+              btnText="Edit"
+              className={classes.EditButton}
+              textStyle={classes.ButtonText}
+              onClick={props.onEdit}
+            />}
           </div>
         </div>
       </div>
@@ -150,6 +162,7 @@ PersonDrawer.propTypes = {
   location: PropTypes.string,
   interests: PropTypes.arrayOf(PropTypes.string),
   staticDrawer: PropTypes.bool,
+  onEdit: PropTypes.bool,
 };
 
 export default PersonDrawer;

--- a/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.js
+++ b/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.js
@@ -3,6 +3,7 @@ import classes from './PersonDrawer.module.css';
 import {Avatar, Drawer} from '@mui/material';
 import PropTypes from 'prop-types';
 import {
+  calculateAge,
   getDateLastMetString,
   getFirstMetTimeString,
 } from '../../functions/dateFormatter';
@@ -25,10 +26,11 @@ const PersonDrawer = (props) => {
         '& .MuiDrawer-paper': {
           width: props.staticDrawer ? '375px' : '460px',
           boxSizing: 'border-box',
+          marginLeft: '128px',
         },
       }}
       variant="persistent"
-      anchor="right"
+      anchor={props.staticDrawer ? 'left' : 'right'}
       open={props.open}
       data-testid="drawer-element"
     >
@@ -66,7 +68,9 @@ const PersonDrawer = (props) => {
             <p data-testid="age-element">
               {'Age: '}
               {props.birthday?
-              <span className={classes.KnownText}>34</span> :
+              <span className={classes.KnownText}>
+                {calculateAge(props.birthday)}
+              </span> :
               unknownDetail}
             </p>
             <p data-testid="gender-element">

--- a/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.js
+++ b/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.js
@@ -11,6 +11,8 @@ import convertSocialMediaNamesToIcons,
 {convertSocialMediaToIcon} from '../../functions/socialMediaIconConverter';
 import {IconButton} from '@mui/material';
 import {getBirthdayString} from '../../functions/dateFormatter';
+import CustomButton from '../CustomButton/CustomButton';
+import classNames from 'classnames';
 
 const PersonDrawer = (props) => {
   const unknownDetail = <span className={classes.UnknownText}>Unknown</span>;
@@ -18,10 +20,10 @@ const PersonDrawer = (props) => {
   return (
     <Drawer
       sx={{
-        'width': '460px',
+        'width': props.staticDrawer ? '375px' : '460px',
         'flexShrink': 0,
         '& .MuiDrawer-paper': {
-          width: '460px',
+          width: props.staticDrawer ? '375px' : '460px',
           boxSizing: 'border-box',
         },
       }}
@@ -54,7 +56,7 @@ const PersonDrawer = (props) => {
               First met {getFirstMetTimeString(props.firstMet)}
             </h2>
           </div>
-          <div className={classes.InfoContent}>
+          <div className={props.staticDrawer ? classes.InfoContent : classNames(classes.InfoContent, classes.InfoContentPadding)}>
             <p data-testid="age-element">
               {'Age: '}
               {props.birthday?
@@ -129,6 +131,7 @@ const PersonDrawer = (props) => {
                  })}
                </span> :unknownDetail}
             </p>
+            <CustomButton btnText="Edit" className={classes.EditButton} textStyle={classes.ButtonText}/>
           </div>
         </div>
       </div>
@@ -146,6 +149,7 @@ PersonDrawer.propTypes = {
   firstMet: PropTypes.instanceOf(Date),
   location: PropTypes.string,
   interests: PropTypes.arrayOf(PropTypes.string),
+  staticDrawer: PropTypes.bool,
 };
 
 export default PersonDrawer;

--- a/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.module.css
+++ b/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.module.css
@@ -7,7 +7,7 @@
     flex-direction: column;
     justify-content: center;
     box-sizing: border-box;
-    padding: 60px;
+    padding: 55px;
 }
 
 .ContentContainer {
@@ -42,6 +42,11 @@
     flex-direction: column;
     align-items: flex-start;
     box-sizing: border-box;
+    padding: 0;
+    align-self: flex-start;
+}
+
+.InfoContentPadding {
     padding: 0 50px;
 }
 
@@ -49,7 +54,7 @@
     font-size: var(--text-medium);
     font-weight: 400;
     margin: 15px 0;
-    color: var(--txt2)
+    color: var(--txt2);
 }
 
 .KnownText {
@@ -71,4 +76,13 @@
 .Icon {
     height: 36px;
     width: 36px;
+}
+
+.EditButton {
+    width: 80px;
+    margin-top: 25px;
+}
+
+.ButtonText {
+    font-size: var(--text-medium);
 }

--- a/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.module.css
+++ b/forgettable-frontend/src/Components/PersonDrawer/PersonDrawer.module.css
@@ -28,6 +28,7 @@
     font-size: var(--text-drawer-title);
     font-weight: 600;
     margin: 5px 0;
+    text-align: center;
 }
 
 .InfoHeader > h2 {
@@ -35,6 +36,7 @@
     font-weight: 400;
     color: var(--txt2);
     margin: 0;
+    text-align: center;
 }
 
 .InfoContent {

--- a/forgettable-frontend/src/components/CustomButton/CustomButton.js
+++ b/forgettable-frontend/src/components/CustomButton/CustomButton.js
@@ -8,7 +8,7 @@ function CustomButton(props) {
   } = props;
   return (
     <div className={classnames(classes.Button, className)} onClick={onClick}>
-      <p className={classes.Text}>{ btnText }</p>
+      <p className={classnames(classes.Text, props.textStyle)}>{ btnText }</p>
     </div>
   );
 }

--- a/forgettable-frontend/src/components/CustomButton/CustomButton.module.css
+++ b/forgettable-frontend/src/components/CustomButton/CustomButton.module.css
@@ -8,8 +8,9 @@
     border:2px solid black;
     border-radius: var(--radius-btn);
     padding: 0 15px 0 15px;
+    box-sizing: border-box;
     width: fit-content;
-    height: 36px;
+    height: 40px;
     cursor: pointer;
     user-select: none;
 }

--- a/forgettable-frontend/src/functions/dateFormatter.js
+++ b/forgettable-frontend/src/functions/dateFormatter.js
@@ -17,3 +17,9 @@ export const getBirthdayString = (timeInMs) => {
                   moment(timeInMs).format('DD MMM YYYY') :
                   '';
 };
+
+export const calculateAge = (timeInMs) => {
+  return timeInMs ?
+                  moment().diff(moment(timeInMs), 'years') :
+                  '';
+};

--- a/forgettable-frontend/src/pages/home/App.js
+++ b/forgettable-frontend/src/pages/home/App.js
@@ -5,7 +5,7 @@ import SearchBar from '../../components/SearchBar/SearchBar';
 import classes from './App.module.css';
 import PersonCardSummary from '../../components/PersonCardSummary/PersonCardSummary';
 import PersonDrawer from '../../components/PersonDrawer/PersonDrawer';
-import { Link } from 'react-router-dom';
+import {Link} from 'react-router-dom';
 import IconButton from '../../components/IconButton/IconButton';
 
 // The maximum summary cards shown on the large screens, small screens show less
@@ -16,22 +16,22 @@ function App() {
   // @TODO: Input real data. Get 12 people and 12 encounters. Get all info needed for seach bar. Get user.
 
   // TEMPORARY FAKE DATA
-  const user = { first_name: 'PersonName' };
+  const user = {first_name: 'PersonName'};
   const personList = [{
     id: '0',
     name: 'Name',
     img: 'https://avatars.githubusercontent.com/u/28725774?v=4',
     firstMet: new Date(),
-    socialMedias: [{ name: 'facebook', link: 'https://www.google.com/' }, { name: 'instagram', link: 'https://www.google.com/' }],
+    socialMedias: [{name: 'facebook', link: 'https://www.google.com/'}, {name: 'instagram', link: 'https://www.google.com/'}],
     location: 'Auckland',
     interests: ['art', 'sewing', 'coding'],
   },
   ];
   for (let i = 1; i < MAX_LATEST_CARDS; i++) {
-    personList[i] = { ...personList[0], name: 'P' + i };
+    personList[i] = {...personList[0], name: 'P' + i};
   }
 
-  const searchBarData = [{ title: 'fgdgf' }, { title: 'joe' }, { title: 'xi' }, { title: 'abcdef' }];
+  const searchBarData = [{title: 'fgdgf'}, {title: 'joe'}, {title: 'xi'}, {title: 'abcdef'}];
   // END TEMP FAKE DATA
 
   const handlePersonHover = (event, index) => {
@@ -63,14 +63,14 @@ function App() {
 
         <div className={classes.home_subtitleContainer}>
           <div className={classes.home_subtitle}>Recently Updated</div>
-          <Link to="/people" style={{ textDecoration: 'none' }}><CustomButton btnText='View All' /></Link>
+          <Link to="/people" style={{textDecoration: 'none'}}><CustomButton btnText='View All' /></Link>
         </div>
 
         <div className={classes.home_cardGridContainer + ' ' + classes.home_personGridContainer}>
           {personList.map((person, index) => {
             return (
               <div key={index} className={classes.home_cardWrapper} onMouseEnter={(event) => handlePersonHover(event, index)}>
-                <Link to={`/people/${person.id}`} style={{ textDecoration: 'none' }}>
+                <Link to={`/people/${person.id}`} style={{textDecoration: 'none'}}>
                   <PersonCardSummary
                     id={person.id}
                     name={person.name}
@@ -85,7 +85,7 @@ function App() {
 
         <div className={classes.home_subtitleContainer}>
           <div className={classes.home_subtitle}>Recently Encounters</div>
-          <Link to="/encounters" style={{ textDecoration: 'none' }}><CustomButton btnText='View All' /></Link>
+          <Link to="/encounters" style={{textDecoration: 'none'}}><CustomButton btnText='View All' /></Link>
         </div>
 
         <div>This is where the encounters grid will go</div>


### PR DESCRIPTION
* Currently, the PeronDrawer component is made for the purpose of the Dashboard and the People list page
  * In this implementation, it is displayed on the right side, as a collapsible drawer (See issue #147) 
* We also need a version of this component that exists on the leftside for the "Person" page (see issue #147)
* Created prop to pass in conditional variable `staticDrawer`, and change the component's styling conditionally
* Updated CustomButton to be more customisable.

Fixes #147

## Updated Props

```js
PersonDrawer.propTypes = {
  open: PropTypes.bool.isRequired,
  id: PropTypes.string,
  name: PropTypes.string.isRequired,
  img: PropTypes.string,
  socialMedias: PropTypes.arrayOf(Object), // See below for an example
  // [{name: 'facebook', link: 'https://www.google.com/'}, {name: 'instagram', link: 'https://www.google.com/'}]
  firstMet: PropTypes.instanceOf(Date),
  location: PropTypes.string,
  interests: PropTypes.arrayOf(PropTypes.string),
  staticDrawer: PropTypes.bool,
  onEdit: PropTypes.bool,
};
```

## Demo

When  `staticDrawer={false}`
![image](https://user-images.githubusercontent.com/62003343/158301526-7922647d-1632-4e18-8ea1-d1e6330c17a6.png)

When `staticDrawer={true}`
![image](https://user-images.githubusercontent.com/62003343/158301581-26dcd929-1e30-4b9e-9e3e-9ffc81a02ba2.png)
