### PR TITLE
Implement `GET /users`

### DIFF
--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -37,3 +37,30 @@ export const createUser = async (
     next(e);
   }
 };
+
+export const getUser = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const auth_id = req.headers.authorization?.["user_id"];
+    const user = await userService.getUserByAuthId(auth_id);
+
+    if (!user) {
+      res.status(httpStatus.NOT_FOUND).end();
+    } else {
+      // Don't return auth_id in the response
+      res.status(httpStatus.OK).json({
+        _id: user._id,
+        first_name: user.first_name,
+        last_name: user.last_name,
+        persons: user.persons,
+        encounters: user.encounters
+      });
+    }
+  
+  } catch (e) {
+    next(e);
+  }
+};

--- a/backend/src/routes/__test__/user.route.test.ts
+++ b/backend/src/routes/__test__/user.route.test.ts
@@ -170,12 +170,10 @@ describe("POST /users", () => {
       .set("Accept", "application/json")
       .send(user1Data);
 
-    const { body: user } = await supertest(app)
+    await supertest(app)
       .get("/api/users")
       .set("Authorization", token)
-      .expect(httpStatus.OK);
-
-    expect(user).toBeFalsy();
+      .expect(httpStatus.NOT_FOUND);
   });
 
   it("User with same UID and info cannot be created twice", async () => {
@@ -220,3 +218,34 @@ describe("POST /users", () => {
       .expect(httpStatus.OK);
   });
 });
+
+describe("GET /users", () => {
+  it("Fetches user with auth_id present in token", async () => {
+    await supertest(app)
+    .post("/api/users")
+    .set("Accept", "application/json")
+    .send(user1Data)
+    .set("Authorization", token)
+    .expect(httpStatus.CREATED);
+
+    const { body: user } = await supertest(app)
+    .get("/api/users")
+    .set("Accept", "application/json")
+    .set("Authorization", token)
+    .expect(httpStatus.OK);
+
+    expect(user.auth_id).toBeUndefined();
+    expect(user.first_name).toEqual(user1Data.first_name);
+    expect(user.last_name).toEqual(user1Data.last_name);
+    expect(user.encounters).toEqual(user1Data.encounters);
+    expect(user.persons).toEqual(user1Data.persons);
+  })
+
+  it("Returns no user when none with auth_id found", async () => {
+    await supertest(app)
+    .get("/api/users")
+    .set("Accept", "application/json")
+    .set("Authorization", token)
+    .expect(httpStatus.NOT_FOUND)
+  })
+})

--- a/backend/src/routes/user.route.ts
+++ b/backend/src/routes/user.route.ts
@@ -2,11 +2,12 @@
  * Route configures endpoints, and attaches controller as an action to each route's REST methods
  */
  import { Router } from 'express';
- import { createUser } from '../controllers/user.controller';
+ import { createUser, getUser } from '../controllers/user.controller';
  
  const routes = Router();
  
  routes.post('/', createUser);
+ routes.get('/', getUser)
  
  export default routes;
  


### PR DESCRIPTION
Addresses: #150 

Implements endpoint `GET /users` that returns a user based on the IdToken in the auth header.
Returns 200 OK with verified and found user
Returns 401 UNAUTHORIZED when token is missing/invalid
Returns 404 NOT FOUND when user does not exist with token

Passes both unit tests added