### PR TITLE
Add `time_updated` to `encounter` model

### DIFF
--- a/backend/src/controllers/encounter.controller.ts
+++ b/backend/src/controllers/encounter.controller.ts
@@ -118,6 +118,7 @@ const getEncounterFromReqBody = (body: any) => {
   const encounter: EncounterModel = {
     title: body.title,
     date: body.date,
+    time_updated: body.time_updated,
     location: body.location,
     description: body.description,
     persons: body.persons,

--- a/backend/src/models/encounter.model.ts
+++ b/backend/src/models/encounter.model.ts
@@ -3,6 +3,7 @@ import mongoose, { Schema, model } from 'mongoose';
 export interface EncounterModel {
   title: string,
   date: Date,
+  time_updated: Date,
   location: string,
   description: string,
   persons: mongoose.Types.ObjectId[]
@@ -10,7 +11,8 @@ export interface EncounterModel {
 
 const schema = new Schema<EncounterModel>({
   title: { type: String, required: true},
-  date: { type: Date, default: Date.now },
+  date: { type: Date, required: false },
+  time_updated: { type: Date, default: new Date(Date.now()), required: true },
   location: { type: String, required: false },
   description: { type: String, required: true },
   persons: { type: [mongoose.Types.ObjectId], required: true },

--- a/backend/src/models/person.model.ts
+++ b/backend/src/models/person.model.ts
@@ -30,7 +30,7 @@ const schema = new Schema<PersonModel>({
   social_media: { type: Map, of: String, required: false },
   image: { type: Buffer, required: false },
   encounters: { type: [mongoose.Types.ObjectId], required: false },
-  time_updated: { type: Date, default: Date.now, required: true },
+  time_updated: { type: Date, default: new Date(Date.now()), required: true },
 });
 
 export default model<PersonModel>('Person', schema);

--- a/backend/src/routes/__test__/encounter.route.test.ts
+++ b/backend/src/routes/__test__/encounter.route.test.ts
@@ -71,6 +71,7 @@ const person2Data: PersonModel = {
 const encounter1Data: EncounterModel = {
     title: "Encounter1",
     date: new Date('2022-02-23'),
+    time_updated: new Date(Date.now()),
     description: 'Met at a cafe',
     location: 'Auckland',
     persons: [] as any
@@ -79,6 +80,7 @@ const encounter1Data: EncounterModel = {
 const encounter2Data: EncounterModel = {
     title: "Encounter2",
     date: new Date('2022-02-24'),
+    time_updated: new Date(Date.now()),
     description: 'Had lunch together',
     location: 'Auckland',
     persons: [] as any
@@ -87,6 +89,7 @@ const encounter2Data: EncounterModel = {
 const encounter3Data = {
     title: "Encounter3",
     date: new Date('2022-05-25'),
+    time_updated: new Date(Date.now()),
     location: 'Auckland',
     persons: [] as any
 }
@@ -94,6 +97,7 @@ const encounter3Data = {
 const encounter4Data= {
     title: "Encounter4",
     description: 'Play badminton together',
+    time_updated: new Date(Date.now()),
     location: 'Auckland',
     persons: [] as any
 }
@@ -102,12 +106,14 @@ const encounter5Data = {
     title: "Encounter5",
     date: new Date('2022-05-25'),
     description: 'Played badminton together',
+    time_updated: new Date(Date.now()),
     persons: [] as any
 }
 
 const encounter6Data = {
     title: "Encounter6",
     date: new Date('2022-02-23'),
+    time_updated: new Date(Date.now()),
     description: 'Met at a cafe',
     location: 'Auckland'
 }
@@ -115,6 +121,7 @@ const encounter6Data = {
 const encounter7Data = {
     date: new Date('2019-08-17'),
     description: 'Shopping',
+    time_updated: new Date(Date.now()),
     location: 'Auckland',
     persons: [] as any
 }
@@ -122,6 +129,7 @@ const encounter7Data = {
 const encounterData: EncounterModel = {
     title: "EncounterData",
     date: new Date("2022-12-02"),
+    time_updated: new Date(Date.now()),
     location: "here",
     description: "we did this and that",
     persons: [] as any,

--- a/backend/src/routes/__test__/encounter.route.test.ts
+++ b/backend/src/routes/__test__/encounter.route.test.ts
@@ -423,6 +423,7 @@ describe('encounter ', () => {
         await supertest(app)
             .put(`/api/encounters/${newEncounterId}`)
             .set('Accept', 'application/json')
+            .set('Authorization', token)
             .send(encounterData)
             .expect(httpStatus.NO_CONTENT)
 
@@ -436,6 +437,7 @@ describe('encounter ', () => {
         await supertest(app)
             .put(`/api/encounters/${123}`)
             .set('Accept', 'application/json')
+            .set('Authorization', token)
             .send(encounterData)
             .expect(httpStatus.BAD_REQUEST)
     });
@@ -445,6 +447,7 @@ describe('encounter ', () => {
         await supertest(app)
             .put(`/api/encounters/622b36166bb3a4e3a1ef62f1`)
             .set('Accept', 'application/json')
+            .set('Authorization', token)
             .send(encounterData)
             .expect(httpStatus.NOT_FOUND)
     });

--- a/backend/src/services/__test__/encounter.service.unit.test.ts
+++ b/backend/src/services/__test__/encounter.service.unit.test.ts
@@ -10,6 +10,7 @@ afterAll(async () => databaseOperations.closeDatabase());
 const encounter1Data: EncounterModel = {
     title: "Encounter1",
     date: new Date('2022-02-23'),
+    time_updated: new Date(Date.now()),
     description: 'Met at a cafe',
     location: 'Auckland',
     persons: ["656e636f756e746572314964", "656e636f756e746572317893"] as any
@@ -20,12 +21,14 @@ const encounter2Data: EncounterModel= {
     description: 'Play badminton together',
     location: 'Auckland',
     persons: ["656e636f756e746572314964", "656e636f756e746572317893"] as any,
+    time_updated: new Date(Date.now()),
     date: null as any
 }
 
 const encounter3Data: EncounterModel = {
     title: "Encounter5",
     date: new Date('2022-05-25'),
+    time_updated: new Date(Date.now()),
     description: 'Played badminton together',
     persons: ["656e636f756e746572314964", "656e636f756e746572317893"] as any,
     location: null as any
@@ -34,6 +37,7 @@ const encounter3Data: EncounterModel = {
 const encounter4Data: EncounterModel = {
     title: null as any,
     date: new Date('2019-08-17'),
+    time_updated: new Date(Date.now()),
     description: 'Shopping',
     location: 'Auckland',
     persons: ["656e636f756e746572314964", "656e636f756e746572317893"] as any,
@@ -42,6 +46,7 @@ const encounter4Data: EncounterModel = {
 const encounter5Data: EncounterModel = {
     title: "Encounter7",
     date: new Date('2022-05-25'),
+    time_updated: new Date(Date.now()),
     location: 'Auckland',
     persons: ["656e636f756e746572314964", "656e636f756e746572317893"] as any,
     description: null as any
@@ -50,6 +55,7 @@ const encounter5Data: EncounterModel = {
 const encounter6Data: EncounterModel = {
     title: "Encounter8",
     date: new Date('2022-05-25'),
+    time_updated: new Date(Date.now()),
     location: 'Auckland',
     persons: null as any,
     description: "This is encounter 8" as any
@@ -58,6 +64,7 @@ const encounter6Data: EncounterModel = {
 const encounter7Data: EncounterModel = {
     title: "Encounter9",
     date: new Date('2022-05-25'),
+    time_updated: new Date(Date.now()),
     location: 'Auckland',
     persons: [] as any,
     description: "This is encounter 9" as any


### PR DESCRIPTION
Addresses #154

Add extra `time_updated` field to `encounter` which defaults to the current time. Also adjusted the equivalent field in `person.model`.

Added field to all test data and added auth headers to those without.