### PR TITLE
Replace query params of GET persons/ with 'term'

### DIFF
--- a/backend/src/controllers/encounter.controller.ts
+++ b/backend/src/controllers/encounter.controller.ts
@@ -155,8 +155,6 @@ export const getAllEncounters = async (
   try {
     if (!user) {
       res.status(httpStatus.NOT_FOUND).end();
-    } else if (!user.encounters.length) {
-      res.status(httpStatus.NO_CONTENT).end();
     } else {
       const foundUserEncounters = await encounterService.getAllEncounters(user.encounters);
       res.status(httpStatus.OK).json(foundUserEncounters).end();

--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -69,8 +69,17 @@ export const getAllPeople = async (
     } else if (!user.persons.length) {
       res.status(httpStatus.NO_CONTENT).end();
     } else {
-      const foundUserPersons = await personService.getPeople(req.query, user.persons);
-      res.status(httpStatus.OK).json(foundUserPersons).end();
+      if (!user.persons.length) {
+        res.status(httpStatus.NO_CONTENT).end();
+      } else {
+        const foundUserPersons = await personService.getPeople(req.query, user.persons);
+        
+        if (!foundUserPersons.length) { 
+          res.status(httpStatus.NO_CONTENT).end();
+        } else {
+          res.status(httpStatus.OK).json(foundUserPersons).end();
+        }
+      }
     }
   } catch (e) {
     next(e);

--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -66,8 +66,6 @@ export const getAllPeople = async (
   try {
     if (!user) {
       res.status(httpStatus.NOT_FOUND).end();
-    } else if (!user.persons.length) {
-      res.status(httpStatus.NO_CONTENT).end();
     } else {
       const foundUserPersons = await personService.getPeople(req.query, user.persons);
       res.status(httpStatus.OK).json(foundUserPersons).end();

--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -69,17 +69,8 @@ export const getAllPeople = async (
     } else if (!user.persons.length) {
       res.status(httpStatus.NO_CONTENT).end();
     } else {
-      if (!user.persons.length) {
-        res.status(httpStatus.NO_CONTENT).end();
-      } else {
-        const foundUserPersons = await personService.getPeople(req.query, user.persons);
-        
-        if (!foundUserPersons.length) { 
-          res.status(httpStatus.NO_CONTENT).end();
-        } else {
-          res.status(httpStatus.OK).json(foundUserPersons).end();
-        }
-      }
+      const foundUserPersons = await personService.getPeople(req.query, user.persons);
+      res.status(httpStatus.OK).json(foundUserPersons).end();
     }
   } catch (e) {
     next(e);

--- a/backend/src/services/person.service.ts
+++ b/backend/src/services/person.service.ts
@@ -5,7 +5,7 @@ import mongoose from 'mongoose';
 import Person, { PersonModel } from '../models/person.model';
 import logger from '../utils/logger';
 
-const stringFields = ['full_name', 'gender', 'location', 'how_we_met', 'organisation'];
+const queryKeys = ['full_name', 'gender', 'location', 'how_we_met', 'organisation']; //first_name and last_name
 
 const createPerson = async (personDetails: PersonModel) => {
   const person = new Person(personDetails);
@@ -28,30 +28,28 @@ const getPersonWithId = async (reqPersonId: string) => {
  * Refer to section 'Duplicate Query Execution under https://mongoosejs.com/docs/migrating_to_6.html
  */
 const getPeople = async (queryParams: any, userPersons: mongoose.Types.ObjectId[]) => {
-  // Log query params if received
-  if (Object.keys(queryParams).length > 0) {
+  // Get all persons from the db that belong to the user
+  let foundUserPersons = await Person.find({ _id: { $in: userPersons } });
+
+  // Filter the found persons by query params
+  if (queryParams.term) {
     logger.info('Query params received:');
     logger.info(queryParams);
-  }
+    const termValue = queryParams.term.toLowerCase();
 
-  // Get all persons from the db that belong to the user
-  const foundUserPersons = await Person.find({ _id: { $in: userPersons } });
-
-  // Filter them by query params (only works with single string fields)
-  return foundUserPersons.filter((person) => {
-    for (const queryKey in queryParams) {
-      if (stringFields.includes(queryKey)) {
-        // Get queryValue and personValue as lowercase strings
-        const queryValue: string = queryParams[queryKey].toLowerCase();
-        const personValue: string = person[queryKey].toLowerCase();
-
-        if (!personValue.includes(queryValue)) {
-          return false;
+    // If no relevant fields in a Person match 'termValue', remove them from the array
+    foundUserPersons = foundUserPersons.filter((person) => {
+      for (let i = 0; i < queryKeys.length; i++) {
+        const personValue = (person[queryKeys[i]] as string).toLowerCase();
+        if (personValue.includes(termValue)) {
+          return true;
         }
       }
-    }
-    return true;
-  });
+      return false;
+    })
+  }
+
+  return foundUserPersons;
 };
 
 const addEncounterToPersons = async (personIds, encounterId) => {

--- a/backend/src/services/person.service.ts
+++ b/backend/src/services/person.service.ts
@@ -36,9 +36,12 @@ const getPeople = async (queryParams: any, userPersons: mongoose.Types.ObjectId[
     // If no relevant fields in a Person match 'termValue', remove them from the array
     foundUserPersons = foundUserPersons.filter((person) => {
       for (let i = 0; i < queryKeys.length; i++) {
-        const personValue = (person[queryKeys[i]] as string).toLowerCase();
-        if (personValue.includes(termValue)) {
-          return true;
+        // Make sure person has a value for current queryKey
+        if (person[queryKeys[i]]) {
+          const personValue = (person[queryKeys[i]] as string).toLowerCase();
+          if (personValue.includes(termValue)) {
+            return true;
+          }
         }
       }
       return false;

--- a/backend/src/services/person.service.ts
+++ b/backend/src/services/person.service.ts
@@ -5,7 +5,7 @@ import mongoose from 'mongoose';
 import Person, { PersonModel } from '../models/person.model';
 import logger from '../utils/logger';
 
-const queryKeys = ['full_name', 'gender', 'location', 'how_we_met', 'organisation']; //first_name and last_name
+const queryKeys = ['first_name', 'last_name', 'location', 'how_we_met', 'organisation'];
 
 const createPerson = async (personDetails: PersonModel) => {
   const person = new Person(personDetails);
@@ -23,10 +23,6 @@ const getPersonWithId = async (reqPersonId: string) => {
   return Person.findOne(query);
 };
 
-/**
- * Note that .clone is necessary to avoid error 'Query was already executed'
- * Refer to section 'Duplicate Query Execution under https://mongoosejs.com/docs/migrating_to_6.html
- */
 const getPeople = async (queryParams: any, userPersons: mongoose.Types.ObjectId[]) => {
   // Get all persons from the db that belong to the user
   let foundUserPersons = await Person.find({ _id: { $in: userPersons } });

--- a/backend/src/services/person.service.ts
+++ b/backend/src/services/person.service.ts
@@ -5,7 +5,7 @@ import mongoose from 'mongoose';
 import Person, { PersonModel } from '../models/person.model';
 import logger from '../utils/logger';
 
-const queryKeys = ['first_name', 'last_name', 'location', 'how_we_met', 'organisation'];
+const queryKeys = ['first_name', 'last_name', 'gender', 'location', 'how_we_met', 'organisation'];
 
 const createPerson = async (personDetails: PersonModel) => {
   const person = new Person(personDetails);


### PR DESCRIPTION
Addresses #161 and #181:
* Replaces the query param scheme of GET persons/ with a single 'term' param
* Changed response if a user's `encounters`/`persons` field is empty, to an empty array with (`200 OK`)

Manual Postman Tests:
* Empty user `encounters`/`persons` fields return empty arrays (`200 OK`) ✔️ 
* Only persons that belong to the `User` found through the `auth_id` are returned (`200 OK`) ✔️ 
* If a `User` is not found returns `404 Not Found` ✔️ 
* If a `User` has no `persons` returns `204 No Content` ✔️ 
* Partial matches of the provided `term` query are applied ✔️ 
    * `first_name`
    * `last_name`
    * `gender`
    * `location`
    * `how_we_met`
    * `organisation`
 * If  the `term` param is empty it is ignored ✔️

To be fixed later:
* Add real unit tests to replace manual tests
