### PR TITLE
Add auth to POST persons/

### DIFF
--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -54,26 +54,31 @@ export const createPerson: POST = async (
 export const getPersonWithId = async (
   req: Request,
   res: Response,
+  next: NextFunction
 ): Promise<void> => {
   logger.info('GET /persons/:id request from frontend');
-
   const authId = req.headers.authorization?.['user_id'];
-  const user = await userService.getUserByAuthId(authId);
 
-  if (!user) {
-    res.status(httpStatus.UNAUTHORIZED).end();
-  } else {
-    // If the person belongs to this user, find it
-    let person: any;
-    if (user.persons.includes(new mongoose.Types.ObjectId(req.params.id))) {
-      person = await personService.getPersonWithId(req.params.id);
-    }
+  try {
+    const user = await userService.getUserByAuthId(authId);
 
-    if (!person) {
-      res.status(httpStatus.NOT_FOUND).end();
+    if (!user) {
+      res.status(httpStatus.UNAUTHORIZED).end();
     } else {
-      res.status(httpStatus.OK).json(person).end();
+      // If the person belongs to this user, find it
+      let person: any;
+      if (user.persons.includes(new mongoose.Types.ObjectId(req.params.id))) {
+        person = await personService.getPersonWithId(req.params.id);
+      }
+
+      if (!person) {
+        res.status(httpStatus.NOT_FOUND).end();
+      } else {
+        res.status(httpStatus.OK).json(person).end();
+      }
     }
+  } catch (e) {
+    next(e);
   }
 };
 

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -24,6 +24,14 @@ export const getUserByAuthId = async (uid) => {
   return user;
 };
 
+export const addPersonId = async(uid, pid) => {
+  const updatedUser = await User.findOneAndUpdate(
+    { auth_id: uid }, 
+    { $push: { persons: pid }},
+    { returnOriginal: false })
+  return updatedUser;
+}
+
 export const deleteUserPerson = async (personID: String) => {
   await User.updateMany({ }, { $pullAll: {persons: [{ _id: personID}]}});
 }
@@ -35,6 +43,7 @@ export const deleteUserEncounter = async (encounterID: String) => {
 const userService = {
   createUser,
   getUserByAuthId,
+  addPersonId,
   deleteUserPerson,
   deleteUserEncounter,
   addEncounterToUser,


### PR DESCRIPTION
[ Continues from #136, addresses [this](https://github.com/se701team3/Forgettable/pull/136#discussion_r825703336) concern ]
Addresses #82:
* Adds auth checks to POST persons/ endpoint
* Adds a missing try catch to the GET persons/:id endpoint

Manual Postman tests:
* If a valid person is provided and a reference is successfully added to the `User`, return `201 Created` ✔️
* If a valid person is provided and a reference is NOT added to the `User`, return `409 Conflict` and delete the new person from the db ✔️
* If an invalid person is provided return `400 Bad Request` ✔️
* If `User` is not found return `404 Not Found` ✔️

To be fixed later:
* Add real unit tests to replace manual tests