### PR TITLE
Refactored test auth token generation to util file

### DIFF
--- a/backend/src/routes/__test__/encounter.route.test.ts
+++ b/backend/src/routes/__test__/encounter.route.test.ts
@@ -3,7 +3,7 @@ import { PersonModel } from '../../models/person.model';
 import { EncounterModel } from 'src/models/encounter.model';
 import app from '../../server';
 import httpStatus from "http-status";
-import axios from 'axios';
+import testUtils from '../../utils/test/test-utils';
 import 'dotenv/config';
 import { UserModel } from 'src/models/user.model';
 
@@ -13,20 +13,9 @@ let token;
 
 beforeAll(async () => {
 
-    //Retrieve token for authentication
-    const email = process.env.FIREBASE_TEST_AUTH_EMAIL;
-    const password = process.env.FIREBASE_TEST_AUTH_PASS;
-    const key = process.env.FIREBASE_TEST_AUTH_KEY;
+    token = await testUtils.generateTestAuthToken();
 
-    let body = {
-        "email": email,
-        "password": password,
-        "returnSecureToken": true
-    }
-    const response = await axios.post(`https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyPassword?key=${key}`, body);
-    token = response.data.idToken;
-
-    databaseOperations.connectDatabase()
+    databaseOperations.connectDatabase();
 });
 afterEach(async () => databaseOperations.clearDatabase());
 afterAll(async () => databaseOperations.closeDatabase());

--- a/backend/src/routes/__test__/person.route.test.ts
+++ b/backend/src/routes/__test__/person.route.test.ts
@@ -2,10 +2,17 @@ import httpStatus from 'http-status';
 import databaseOperations from '../../utils/test/db-handler';
 import { PersonModel } from '../../models/person.model';
 import app from '../../server';
+import testUtils from '../../utils/test/test-utils';
 
 const supertest = require('supertest');
 
-beforeAll(async () => databaseOperations.connectDatabase());
+let token;
+
+beforeAll(async () => {
+  token = await testUtils.generateTestAuthToken();
+
+  databaseOperations.connectDatabase();
+});
 afterEach(async () => databaseOperations.clearDatabase());
 afterAll(async () => databaseOperations.closeDatabase());
 

--- a/backend/src/routes/__test__/user.route.test.ts
+++ b/backend/src/routes/__test__/user.route.test.ts
@@ -3,28 +3,16 @@ import databaseOperations from "../../utils/test/db-handler";
 
 import { PersonModel } from "../../models/person.model";
 import app from "../../server";
-import axios from "axios";
+import testUtils from "../../utils/test/test-utils";
 import "dotenv/config";
 
 const supertest = require("supertest");
 
-let token: String;
+let token;
 
 beforeAll(async () => {
-  const email = process.env.FIREBASE_TEST_AUTH_EMAIL;
-  const password = process.env.FIREBASE_TEST_AUTH_PASS;
-  const key = process.env.FIREBASE_TEST_AUTH_KEY;
-
-  let body = {
-    email: email,
-    password: password,
-    returnSecureToken: true,
-  };
-  const response = await axios.post(
-    `https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyPassword?key=${key}`,
-    body
-  );
-  token = response.data.idToken;
+  
+  token = await testUtils.generateTestAuthToken();
 
   databaseOperations.connectDatabase();
 });

--- a/backend/src/utils/test/test-utils.ts
+++ b/backend/src/utils/test/test-utils.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+const generateTestAuthToken = async () => {
+    
+    //Retrieve token for authentication
+    const email = process.env.FIREBASE_TEST_AUTH_EMAIL;
+    const password = process.env.FIREBASE_TEST_AUTH_PASS;
+    const key = process.env.FIREBASE_TEST_AUTH_KEY;
+
+    let body = {
+        "email": email,
+        "password": password,
+        "returnSecureToken": true
+    }
+
+    const response = await axios.post(`https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyPassword?key=${key}`, body);
+    return response.data.idToken;
+};
+
+const testUtils = {
+    generateTestAuthToken,
+};
+
+export default testUtils;


### PR DESCRIPTION
Fixes: #163 

Refactored the test auth token generation into a function called `generateTestAuthToken()`, this function is placed in `test-utils.ts` at `backend/src/utils/test/test-utils.ts`. 

**Testing Notes:**
* All unit tests were run before and after the refactor, the test results from both tests were identical