### PR TITLE
GET persons/:id tests

### DIFF
--- a/backend/src/routes/__test__/person.route.test.ts
+++ b/backend/src/routes/__test__/person.route.test.ts
@@ -1,8 +1,10 @@
 import httpStatus from 'http-status';
 import databaseOperations from '../../utils/test/db-handler';
+
 import { PersonModel } from '../../models/person.model';
 import app from '../../server';
 import testUtils from '../../utils/test/test-utils';
+import "dotenv/config";
 
 const supertest = require('supertest');
 
@@ -10,13 +12,19 @@ let token;
 
 beforeAll(async () => {
   token = await testUtils.generateTestAuthToken();
-
   databaseOperations.connectDatabase();
 });
 afterEach(async () => databaseOperations.clearDatabase());
 afterAll(async () => databaseOperations.closeDatabase());
 
-const requestPersonData:PersonModel = {
+const reqUserData = {
+  first_name: 'Bing',
+  last_name: 'Bong',
+  encounters: [] as any,
+  persons: [] as any,
+}
+
+const person1Data:PersonModel = {
   first_name: 'testFirstName',
   last_name: 'testLastName',
   interests: ['a', 'b'],
@@ -32,38 +40,61 @@ const requestPersonData:PersonModel = {
   social_media: null as any
 };
 
-describe('person ', () => {
-  it('can be created correctly', async () => {
-    await supertest(app).post('/api/persons')
+describe('Creating a person', () => {
+  it('Can be created and stored in the user', async () => {
+    // Create a new user
+    await supertest(app).post('/api/users')
       .set('Accept', 'application/json')
-      .send(requestPersonData)
+      .set('Authorization', token)
+      .send(reqUserData);
+
+    // Create a new person and store it in the user
+    const { body: createdPerson } = await supertest(app).post('/api/persons')
+      .set('Accept', 'application/json')
+      .send(person1Data)
+      .set("Authorization", token)
       .expect(httpStatus.CREATED);
 
-    const { body } = await supertest(app).get('/api/persons');
-    expect(body).toHaveLength(1);
-    const result:PersonModel = body[0];
-    expect(result.first_name).toEqual(requestPersonData.first_name);
+    // Ensure user contains reference to the new person
+    const { body: user } = await supertest(app).get("/api/users")
+      .set("Accept", "application/json")
+      .set("Authorization", token)
+      .expect(httpStatus.OK);
+
+    expect(user.persons).toEqual([createdPerson._id]);
   });
 
-  it('is updated correctly', async () => {
-    // create a person
-    const newPerson = await supertest(app).post('/api/persons').set('Accept', 'application/json').send(requestPersonData);
-    const newPersonId = newPerson._body._id;
-    expect(newPerson._body.location).toBe(requestPersonData.location);
+  it ('Can be updated correctly', async () => {
+    // Create a new user
+    await supertest(app).post('/api/users')
+      .set('Accept', 'application/json')
+      .set('Authorization', token)
+      .send(reqUserData);
 
-    // change the data
+    // Create a new person and store it in the user
+    const { body : newPerson } = await supertest(app).post('/api/persons')
+      .set('Accept', 'application/json')
+      .send(person1Data)
+      .set("Authorization", token)
+      .expect(httpStatus.CREATED);
+
+    // Change the person's data
     const changedLocation = 'Someplace else';
-    requestPersonData.location = changedLocation;
+    person1Data.location = changedLocation;
 
-    // update a person
-    await supertest(app)
-        .put(`/api/persons/${newPersonId}`)
-        .set('Accept', 'application/json')
-        .send(requestPersonData)
-        .expect(httpStatus.NO_CONTENT);
+    // Update the person and check it was successful
+    await supertest(app).put(`/api/persons/${newPerson._id}`)
+      .set('Accept', 'application/json')
+      .send(person1Data)
+      .set("Authorization", token)
+      .expect(httpStatus.NO_CONTENT);
+    
+    // Retrieve person from database, and check that the updated person contains the changed location
+    const { body: updatedPerson } = await supertest(app).get(`/api/persons/${newPerson._id}`)
+      .set('Accept','application/json')
+      .set("Authorization", token)
+      .expect(httpStatus.OK);
 
-    // retrieve encounter from database, and check that the updated encounter contains the changed location
-    const resPerson = await supertest(app).get(`/api/persons/${newPersonId}`);
-    expect(resPerson._body.location).toBe(requestPersonData.location);
+    expect(updatedPerson.location).toEqual(changedLocation);
   });
 });

--- a/backend/src/routes/__test__/person.route.test.ts
+++ b/backend/src/routes/__test__/person.route.test.ts
@@ -74,7 +74,7 @@ const person3Data: PersonModel = {
   social_media: null as any
 }
 
-describe('Creating a person', () => {
+describe('POST persons/', () => {
   it('Can be created and stored in the user', async () => {
     // Create a new user
     await supertest(app).post('/api/users')
@@ -133,7 +133,7 @@ describe('Creating a person', () => {
   });
 });
 
-describe('Getting persons', () => {
+describe('GET persons/:id', () => {
   it ('Can be retrieved by id', async () => {
     // Create a new user
     await supertest(app).post('/api/users')

--- a/backend/src/routes/__test__/person.route.test.ts
+++ b/backend/src/routes/__test__/person.route.test.ts
@@ -5,6 +5,8 @@ import { PersonModel } from '../../models/person.model';
 import app from '../../server';
 import testUtils from '../../utils/test/test-utils';
 import "dotenv/config";
+import personService from '../../services/person.service';
+import userService from '../../services/user.service';
 
 const supertest = require('supertest');
 
@@ -24,21 +26,53 @@ const reqUserData = {
   persons: [] as any,
 }
 
-const person1Data:PersonModel = {
-  first_name: 'testFirstName',
-  last_name: 'testLastName',
-  interests: ['a', 'b'],
-  organisation: 'testorg',
+const person1Data: PersonModel = {
+  first_name: 'Ping',
+  last_name: 'Pong',
+  interests: ['video games', 'hockey'],
+  organisation: 'helloc',
   time_updated: new Date('2022-01-01'),
-  how_we_met: 'testmet',
+  how_we_met: 'Hockey club',
   birthday: new Date('2002-12-12'),
   encounters: [] as any,
   first_met: new Date('2022-01-01'),
-  gender: "other",
+  gender: "male",
+  location: "Auckland",
   image: null as any,
-  location: 'Someplace',
   social_media: null as any
 };
+
+const person2Data: PersonModel = {
+  first_name: 'Adam',
+  last_name: 'Bong',
+  interests: ['badminton', 'golf'],
+  organisation: 'helloc',
+  time_updated: new Date('2022-02-23'),
+  how_we_met: 'Skype',
+  birthday: new Date('2001-07-16'),
+  encounters: [] as any,
+  first_met: null as any,
+  gender: "male",
+  image: null as any,
+  location: null as any,
+  social_media: null as any
+}
+
+const person3Data: PersonModel = {
+  first_name: 'Billy',
+  last_name: 'John',
+  interests: ['surfing', 'cooking'],
+  organisation: 'an organisation',
+  time_updated: new Date('2022-02-23'),
+  how_we_met: 'At the park',
+  birthday: new Date('2001-07-16'),
+  encounters: [] as any,
+  first_met: null as any,
+  gender: "male",
+  image: null as any,
+  location: null as any,
+  social_media: null as any
+}
 
 describe('Creating a person', () => {
   it('Can be created and stored in the user', async () => {
@@ -96,5 +130,76 @@ describe('Creating a person', () => {
       .expect(httpStatus.OK);
 
     expect(updatedPerson.location).toEqual(changedLocation);
+  });
+});
+
+describe('Getting persons', () => {
+  it ('Can be retrieved by id', async () => {
+    // Create a new user
+    await supertest(app).post('/api/users')
+      .set('Accept', 'application/json')
+      .set('Authorization', token)
+      .send(reqUserData);
+
+    // Create a new person and store it in the user
+    const { body: createdPerson } = await supertest(app).post('/api/persons')
+      .set('Accept', 'application/json')
+      .send(person1Data)
+      .set("Authorization", token)
+      .expect(httpStatus.CREATED);
+
+    // Attempt to retrieve it
+    const { body: retrievedPerson } = await supertest(app).get(`/api/persons/${createdPerson._id}`)
+      .set('Accept','application/json')
+      .set("Authorization", token)
+      .expect(httpStatus.OK);
+
+    expect(retrievedPerson._id).toEqual(createdPerson._id);
+  });
+
+  it ('Is not retrieved if the user does not contain it', async () => {
+    // Create a new user
+    const { body: user } = await supertest(app).post('/api/users')
+      .set('Accept', 'application/json')
+      .set('Authorization', token)
+      .send(reqUserData);
+
+    // Create three persons and store only the first two in the user
+    const { body : person1 } = await supertest(app).post('/api/persons')
+      .set('Accept', 'application/json')
+      .send(person1Data)
+      .set("Authorization", token)
+      .expect(httpStatus.CREATED);
+
+    const { body : person2 } = await supertest(app).post('/api/persons')
+      .set('Accept', 'application/json')
+      .send(person2Data)
+      .set("Authorization", token)
+      .expect(httpStatus.CREATED);  
+
+    const person3 = await personService.createPerson(person3Data);
+
+    // Ensure only person1 and person2 can be retrieved
+    await supertest(app).get(`/api/persons/${person1._id}`)
+      .set('Accept','application/json')
+      .set("Authorization", token)
+      .expect(httpStatus.OK);
+
+    await supertest(app).get(`/api/persons/${person2._id}`)
+      .set('Accept','application/json')
+      .set("Authorization", token)
+      .expect(httpStatus.OK);
+
+    await supertest(app).get(`/api/persons/${person3._id}`)
+      .set('Accept','application/json')
+      .set("Authorization", token)
+      .expect(httpStatus.NOT_FOUND);
+  });
+
+  it ('Returns "Unauthorized" if the user does not have a valid auth_id', async () => {
+      await supertest(app).get(`/api/persons/FAKE_PERSON_ID`)
+        .set('Accept','application/json')
+        .set("Authorization", "FAKE_AUTH_TOKEN")
+        .expect(httpStatus.UNAUTHORIZED);
   });
 });

--- a/backend/src/services/__test__/person.service.unit.test.ts
+++ b/backend/src/services/__test__/person.service.unit.test.ts
@@ -39,6 +39,20 @@ const person1Data:PersonModel = {
     social_media: null as any
   };
 
+  describe('Getting persons', () => {
+    it ('Can retrieve an id that exists', async () => {
+      const createdPerson = await personService.createPerson(person1Data);
+      const retrievedPerson = await personService.getPersonWithId(createdPerson._id.toString());
+  
+      expect(retrievedPerson?._id).toEqual(createdPerson._id);
+    });
+  
+    it ('Returns null if an id does not exist', async () => {
+      const retrievedPerson = await personService.getPersonWithId('some_fake_id');
+      expect(retrievedPerson).toBeNull();
+    });
+  })
+
   describe('Add encounter to person', () => {
     it ('Successfully add an encounter to a Person', async () => {
         const person1 = await personService.createPerson(person1Data);


### PR DESCRIPTION
Adds the `Getting Persons` section to the `person.routes` test suite, and fixes the broken `Creating a person` tests:
![route](https://user-images.githubusercontent.com/57572181/158512691-21590916-ad0c-43e5-9180-a085d12520b6.png)

Also adds a `Getting Persons` section to the `person.service` suite.
![service](https://user-images.githubusercontent.com/57572181/158535688-fd5e339b-b807-4dbd-a091-db26bdc0152d.png)

