### PR TITLE
Added query params to GET /encounters endpoint

### DIFF
--- a/backend/src/controllers/encounter.controller.ts
+++ b/backend/src/controllers/encounter.controller.ts
@@ -194,7 +194,7 @@ export const getAllEncounters = async (
     if (!user) {
       res.status(httpStatus.NOT_FOUND).end();
     } else {
-      const foundUserEncounters = await encounterService.getAllEncounters(user.encounters);
+      const foundUserEncounters = await encounterService.getAllEncounters(req.query, user.encounters);
       res.status(httpStatus.OK).json(foundUserEncounters).end();
     }
   } catch (e) {

--- a/backend/src/services/encounter.service.ts
+++ b/backend/src/services/encounter.service.ts
@@ -1,6 +1,9 @@
 /* eslint-disable no-underscore-dangle */
 import mongoose from 'mongoose';
 import Encounter, { EncounterModel } from '../models/encounter.model';
+import logger from '../utils/logger';
+
+const queryKeys = ['title', 'location', 'description'];
 
 const createEncounter = async (encounterDetails: EncounterModel) => {
   const encounter = new Encounter(encounterDetails);
@@ -19,9 +22,31 @@ const createEncounter = async (encounterDetails: EncounterModel) => {
 
 const getEncounter = async (encounterId) => Encounter.findOne({_id: encounterId});
 
-const getAllEncounters = async (userEncounters: mongoose.Types.ObjectId[]) => {
+const getAllEncounters = async (queryParams: any, userEncounters: mongoose.Types.ObjectId[]) => {
+  
   // Get all encounters from the db which belongs to the user
-  const foundUserEncounters = await Encounter.find({ _id: { $in: userEncounters } });
+  let foundUserEncounters = await Encounter.find({ _id: { $in: userEncounters } });
+
+  // Filter the found encounters by query params
+  if (queryParams.term) {
+    logger.info('Query params received:');
+    logger.info(queryParams);
+    const termValue = queryParams.term.toLowerCase();
+
+    // If no relevant fields in an Encounter match 'termValue', remove them from the array
+    foundUserEncounters = foundUserEncounters.filter((encounter) => {
+      for (let i = 0; i < queryKeys.length; i++) {
+        // Make sure person has a value for current queryKey
+        if (encounter[queryKeys[i]]) {
+          const encounterValue = (encounter[queryKeys[i]] as string).toLowerCase();
+          if (encounterValue.includes(termValue)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    })
+  }
 
   return foundUserEncounters;
 };


### PR DESCRIPTION
Fixes: #143 and Addresses: #181 

* Added query param to `GET /encounters`. It is a single query param called `term` which searches any single `string` field in the `Encounter` model. The given query `string` does not need to be exact strings. 

Manual Postman Tests:
* Only encounters that belong to the `User` found through the `auth_id` are returned (`200 OK`)✔️ 
* Empty user `encounters` field returns empty arrays (`200 OK`)✔️ 
* If a `User` is not found return `404 Not Found`✔️ 
* Fields where partial matching with the provided query `term` is applied:
    * `title`✔️
    * `location`✔️
    * `description`✔️
 * If  the `term` param is empty it is ignored✔️

Example Usage:
* To call the endpoint with a query param: `http://localhost:3001/api/encounters?term=a string of some kind`

To be added later:
* Add unit tests to replace manual testing