### PR TITLE
Add embedded encounters to GET /persons/:id and GET /encounters/:id

### DIFF
--- a/backend/src/controllers/encounter.controller.ts
+++ b/backend/src/controllers/encounter.controller.ts
@@ -10,6 +10,7 @@ import logger from '../utils/logger';
 import { EncounterModel } from '../models/encounter.model';
 import userService, { getUserByAuthId } from '../services/user.service';
 import personService from '../services/person.service';
+import getPersonDetails from './utils/controller-utils';
 
 // Util function that won't be needed regularly
 const getEncounterFromReqBody = (body: any) => {
@@ -133,7 +134,9 @@ export const getEncounter = async (
       // Find encounter from database
       const encounter = await encounterService.getEncounter(encounterId);
       // Notify frontend that the operation was successful
-      res.status(httpStatus.OK).json(encounter).end();
+      let encounterDto = JSON.parse(JSON.stringify(encounter));
+      encounterDto.persons = await Promise.all(encounterDto.persons.map(async (personId: any) => { return (await getPersonDetails(personId)) }));
+      res.status(httpStatus.OK).json(encounterDto).end();
     } else {
       res.sendStatus(httpStatus.NOT_FOUND).end();
     }

--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -9,6 +9,7 @@ import { PersonModel } from 'src/models/person.model';
 import userService from '../services/user.service';
 import personService from '../services/person.service';
 import encounterService from '../services/encounter.service';
+import getPersonDetails from './utils/controller-utils';
 
 import logger from '../utils/logger';
 import { POST } from './controller.types';
@@ -67,14 +68,27 @@ export const getPersonWithId = async (
     } else {
       // If the person belongs to this user, find it
       let person: any;
+      let personDto: any;
       if (user.persons.includes(new mongoose.Types.ObjectId(req.params.id))) {
         person = await personService.getPersonWithId(req.params.id);
+
+        //Adds embedded encounters with user details to returned person
+        //The stringify and parse combo removes typing and allows altering of the parsed objects.
+        personDto = JSON.parse(JSON.stringify(person));
+        personDto.encounters = JSON.parse(JSON.stringify(
+          await Promise.all(personDto.encounters.map(
+            async (encounterId: any) => { return (await encounterService.getEncounter(encounterId)) }))));
+
+        for (let i = 0; i < personDto.encounters.length; i++ ) {
+          personDto.encounters[i].persons = await Promise.all(personDto.encounters[i].persons.map(
+            async (personsId: any) => { return (await getPersonDetails(personsId))}));
+        }
       }
 
       if (!person) {
         res.status(httpStatus.NOT_FOUND).end();
       } else {
-        res.status(httpStatus.OK).json(person).end();
+        res.status(httpStatus.OK).json(personDto).end();
       }
     }
   } catch (e) {
@@ -189,4 +203,3 @@ export const updatePersonWithId = async (
     next(error);
   }
 };
-

--- a/backend/src/controllers/utils/controller-utils.ts
+++ b/backend/src/controllers/utils/controller-utils.ts
@@ -1,0 +1,11 @@
+import personService from "../../services/person.service"
+
+export default async function getPersonDetails (personId: any) {
+    let person = await personService.getPersonWithId(personId)
+    return {
+      _id: person?._id,
+      first_name: person?.first_name,
+      last_name: person?.last_name,
+      image: person?.image
+    }
+  }


### PR DESCRIPTION
Addresses #208 

Alter the return of GET /persons/:id to include nested encounter data with person data included. Also alters the endpoint GET /encounters/:id to include user data.

All tests for the routes still pass.

Also worked on by:
@jimwang6012 
@lin8231 