### PR TITLE
Embedded person details in encounters returned by `GET /encounters`

### DIFF
--- a/backend/src/controllers/encounter.controller.ts
+++ b/backend/src/controllers/encounter.controller.ts
@@ -197,7 +197,16 @@ export const getAllEncounters = async (
     if (!user) {
       res.status(httpStatus.NOT_FOUND).end();
     } else {
-      const foundUserEncounters = await encounterService.getAllEncounters(req.query, user.encounters);
+
+      //The stringify and parse combo removes typing and allows the persons field in each encounter to be altered
+      const foundUserEncounters = JSON.parse(JSON.stringify(await encounterService.getAllEncounters(req.query, user.encounters)));
+
+      //Adds embedded person details to the returned encounters
+      for (let i = 0; i < foundUserEncounters.length; i++) {
+        foundUserEncounters[i].persons = await Promise.all(foundUserEncounters[i].persons.map(
+          async (personsId: any) => { return (await getPersonDetails(personsId))}));
+      }
+
       res.status(httpStatus.OK).json(foundUserEncounters).end();
     }
   } catch (e) {


### PR DESCRIPTION
Addresses: #215 

Also worked on by:
@AdamAWiener 
@lin8231 

Pull Request Changes:

* Changed the return of the `GET /encounters` endpoint to include nested person data for each associated `person` in each `encounter`. 

Manual Postman Tests:
* The response body from the `GET /encounters` endpoint contains both the encounter data and the nested person details. 

Example Response Body:

![image](https://user-images.githubusercontent.com/68952466/158884651-26fee93a-f467-4f96-ab1c-92fd979caf73.png)
