### PR TITLE
Person card update: Fix a number of bugs

### DIFF
--- a/forgettable-frontend/src/components/PersonCard/PersonCard.css
+++ b/forgettable-frontend/src/components/PersonCard/PersonCard.css
@@ -1,6 +1,0 @@
-/* .MuiAvatarGroup-avatar {
-    height: 20px;
-    width: 20px;
-    font-size: 12px;
-    font-weight: bold;
-} */

--- a/forgettable-frontend/src/components/PersonCard/PersonCard.css
+++ b/forgettable-frontend/src/components/PersonCard/PersonCard.css
@@ -1,6 +1,6 @@
-.MuiAvatarGroup-avatar {
+/* .MuiAvatarGroup-avatar {
     height: 20px;
     width: 20px;
     font-size: 12px;
     font-weight: bold;
-}
+} */

--- a/forgettable-frontend/src/components/PersonCard/PersonCard.js
+++ b/forgettable-frontend/src/components/PersonCard/PersonCard.js
@@ -32,9 +32,9 @@ const PersonCard = (props) => {
     props.socialMedias.map((socialMedia) => {
       return (
         <Avatar
-          key={socialMedia}
-          src={convertSocialMediaToIcon(socialMedia)}
-          alt={socialMedia}
+          key={socialMedia.name}
+          src={convertSocialMediaToIcon(socialMedia.name)}
+          alt={socialMedia.name}
         >
         </Avatar>
       );
@@ -146,6 +146,12 @@ const PersonCard = (props) => {
                   spacing={2}
                   aria-label="social-media-icons"
                   data-testid="social-media-icons-element"
+                  sx={{
+                    '& .MuiAvatar-root': {
+                      width: 20,
+                      height: 20,
+                      fontSize: 15},
+                  }}
                 >
                   { socialMediaIcons }
                 </AvatarGroup>

--- a/forgettable-frontend/src/components/PersonCard/PersonCard.js
+++ b/forgettable-frontend/src/components/PersonCard/PersonCard.js
@@ -53,7 +53,7 @@ const PersonCard = (props) => {
 
   return (
     <StyledEngineProvider injectFirst>
-      <div className={classes.PersonCard}>
+      <div className={classes.PersonCard} onClick={props.onClick}>
         <div className={classes.ContentContainer}>
           <Avatar
             alt={props.name}

--- a/forgettable-frontend/src/components/PersonCard/PersonCard.js
+++ b/forgettable-frontend/src/components/PersonCard/PersonCard.js
@@ -5,7 +5,6 @@ import IconButton from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
-import './PersonCard.css';
 import {convertSocialMediaToIcon} from '../../functions/socialMediaIconConverter';
 import PropTypes from 'prop-types';
 import {getFirstMetTimeString, getDateLastMetString} from '../../functions/dateFormatter';
@@ -21,10 +20,12 @@ const PersonCard = (props) => {
   const open = Boolean(anchorEl);
 
   const handleClick = (event) => {
+    event.stopPropagation();
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = () => {
+  const handleClose = (event) => {
+    event.stopPropagation();
     setAnchorEl(null);
   };
 

--- a/forgettable-frontend/src/components/PersonCard/PersonCard.js
+++ b/forgettable-frontend/src/components/PersonCard/PersonCard.js
@@ -134,7 +134,7 @@ const PersonCard = (props) => {
               <p className={classes.Encounters}
                 data-testid="encounters-element"
               >
-                  Encounters: {props.numEncounters} times
+                  Encounters: {props.numEncounters || '0'} times
               </p>
               <p className={classes.LastMet}
                 data-testid="last-met-element"

--- a/forgettable-frontend/src/components/PersonCard/PersonCard.module.css
+++ b/forgettable-frontend/src/components/PersonCard/PersonCard.module.css
@@ -9,6 +9,7 @@
     display: flex;
     padding: 28px;
     box-sizing: border-box;
+    cursor: pointer;
 }
 
 .ContentContainer {

--- a/forgettable-frontend/src/components/PersonCard/__tests__/__snapshots__/PersonCard.test.js.snap
+++ b/forgettable-frontend/src/components/PersonCard/__tests__/__snapshots__/PersonCard.test.js.snap
@@ -107,6 +107,7 @@ exports[`renders PersonCard UI with correct hierarchy 1`] = `
             data-testid="encounters-element"
           >
             Encounters: 
+            0
              times
           </p>
           <p
@@ -124,6 +125,15 @@ exports[`renders PersonCard UI with correct hierarchy 1`] = `
               data-testid="social-media-icons-element"
               max={2}
               spacing={2}
+              sx={
+                Object {
+                  "& .MuiAvatar-root": Object {
+                    "fontSize": 15,
+                    "height": 20,
+                    "width": 20,
+                  },
+                }
+              }
             />
           </div>
         </div>


### PR DESCRIPTION
* CSS class was affecting global MUIs before, fixed this
* Encounter card's avatar group now fixed. 
Before: 
  ![image](https://user-images.githubusercontent.com/62003343/158960749-ae70b32c-7da7-471f-bc78-d7387e8fb59e.png)
After:
 ![image](https://user-images.githubusercontent.com/62003343/158960615-f047ef0a-9eb2-4168-8780-feb25d4c53b2.png)

Also:
* PersonCard now can navigate

Fixes #239 and #243 