### PR TITLE
Update create/edit person page

### DIFF
--- a/forgettable-frontend/src/components/CustomButton/CustomButton.js
+++ b/forgettable-frontend/src/components/CustomButton/CustomButton.js
@@ -7,7 +7,7 @@ function CustomButton(props) {
     btnText, onClick, className,
   } = props;
   return (
-    <button className={classnames(classes.Button, className)} onClick={onClick}>
+    <button className={classnames(classes.Button, className)} onClick={onClick} type={props.type}>
       <p className={classnames(classes.Text, props.textStyle)}>{ btnText }</p>
     </button>
   );

--- a/forgettable-frontend/src/components/CustomButton/CustomButton.module.css
+++ b/forgettable-frontend/src/components/CustomButton/CustomButton.module.css
@@ -13,10 +13,11 @@
     height: 40px;
     cursor: pointer;
     user-select: none;
+    background-color: var(--bkgd);
 }
 
 .Button:hover{
-    background-color: var(--bkgd);
+    background-color: var(--hilit);
 }
 
 .Text{

--- a/forgettable-frontend/src/components/InputField/InputField.js
+++ b/forgettable-frontend/src/components/InputField/InputField.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {useState} from 'react';
 import styles from './InputField.module.css';
 
@@ -27,6 +27,10 @@ export default function InputField({inputLabel, inputType, placeholder,
      * Retrieve state of input component to be rendered in a responsive manner.
      */
   const [inputState, setInput] = useState(inputStateValue);
+
+  useEffect(() => {
+    setInput(inputStateValue);
+  }, [inputStateValue]);
 
   /**
      * Types allowed for innput component styling.

--- a/forgettable-frontend/src/components/InputField/InputField.js
+++ b/forgettable-frontend/src/components/InputField/InputField.js
@@ -11,14 +11,14 @@ import styles from './InputField.module.css';
  * for the multiline style. See UI design for more details.
  *
  * Function Arguments:
- * "inputLabel" refers to the label associated with the text input component.
- * "inputType" refers to the "inputType" parameter as mentioned above.
- * "placeholder" refers to the placeholder text in the component.
- * "dataType" refers to the data format allowed as input.
- * "inputID" refers to the ID for the data associated with the input.
- * "inputStateValue" refers to the pre-filled value when the input is rendered.
- * "autoFocusState" refers to the autoFocus attribute, parameter is a Boolean.
- * "requiredState" refers to the required attribute, parameter is a Boolean.
+ * @param inputLabel refers to the label associated with the text input component.
+ * @param inputType refers to the "inputType" parameter as mentioned above.
+ * @param placeholder refers to the placeholder text in the component.
+ * @param dataType refers to the data format allowed as input.
+ * @param inputID refers to the ID for the data associated with the input.
+ * @param inputStateValue refers to the pre-filled value when the input is rendered.
+ * @param autoFocusState refers to the autoFocus attribute, parameter is a Boolean.
+ * @param requiredState refers to the required attribute, parameter is a Boolean.
  */
 
 export default function InputField({inputLabel, inputType, placeholder,

--- a/forgettable-frontend/src/components/InputField/InputField.module.css
+++ b/forgettable-frontend/src/components/InputField/InputField.module.css
@@ -1,3 +1,5 @@
+@import '../../colours.css';
+
 .inputLabelPrimary {
     font-size: var(--text-medium);
     font-weight: var(--font-medium);
@@ -22,12 +24,16 @@
 }
 
 .inputFieldPrimary{
-    font-size: var(--text-medium);
-    width: 375px;
-    height: 40px;
+    font-size: var(--text-normal);
+    width: 340px;
+    height: 35px;
     border-radius: var(--radius-btn);
-    margin-top: 5px;
+    border: 1.5px solid var(--bord);
+    box-shadow: none;
+    margin-top: 8px;
     padding: 10px;
+    padding-left: 18px;
+    font-family: 'Poppins', sans-serif;
 }
 
 .inputFieldSecondary{
@@ -37,6 +43,7 @@
     border-radius: var(--radius-btn);
     margin-left: 10px;
     padding: 10px;
+    font-family: 'Poppins', sans-serif;
 }
 
 .inputFieldMultiLine {

--- a/forgettable-frontend/src/functions/dateFormatter.js
+++ b/forgettable-frontend/src/functions/dateFormatter.js
@@ -46,3 +46,9 @@ export const getLongDateStringWithSlashes = (date) => {
           moment(date).format('DD/MM/YYYY') :
           'Unknown';
 };
+
+export const getInputDateFormatString = (date) => {
+  return date ?
+          moment(date).format('yyyy-MM-DD') :
+          '';
+};

--- a/forgettable-frontend/src/functions/helper.js
+++ b/forgettable-frontend/src/functions/helper.js
@@ -1,3 +1,5 @@
+import {toast} from 'react-toastify';
+
 export function stringToColor(string) {
   let hash = 0;
   let i;
@@ -25,4 +27,29 @@ export function stringAvatar(name) {
     },
     children: `${name.split(' ')[0][0]}${name.split(' ')[1][0]}`,
   };
+}
+
+export function toastGenerator(type, message, time) {
+  /* only handles success / error type */
+  if (type == 'success') {
+    return toast.success(message, {
+      position: 'bottom-center',
+      autoClose: time,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: true,
+      draggable: true,
+      progress: undefined,
+    });
+  } else {
+    return toast.error(message, {
+      position: 'bottom-center',
+      autoClose: time,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: true,
+      draggable: true,
+      progress: undefined,
+    });
+  }
 }

--- a/forgettable-frontend/src/pages/EncountersListPage/EncountersListPage.js
+++ b/forgettable-frontend/src/pages/EncountersListPage/EncountersListPage.js
@@ -11,6 +11,7 @@ import {deleteEncounter, getAllEncounters, searchEncounter, getEncountersByPage}
 import CustomModal from '../../components/CustomModal/CustomModal';
 import {ToastContainer, toast} from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import {toastGenerator} from '../../functions/helper';
 
 /*
  * This page lists out all the Encounters the user created.

--- a/forgettable-frontend/src/pages/EncountersListPage/EncountersListPage.js
+++ b/forgettable-frontend/src/pages/EncountersListPage/EncountersListPage.js
@@ -75,25 +75,9 @@ export default function EncountersListPage() {
     if (result) {
       const updatedEncountersList = await getAllEncounters();
       setEncounterList(updatedEncountersList);
-      toast.success('Encounter deleted!', {
-        position: 'bottom-center',
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      });
+      toastGenerator('success', 'Encounter deleted!', 3000);
     } else {
-      toast.error('Something went wrong... :(', {
-        position: 'bottom-center',
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      });
+      toastGenerator('error', 'Something went wrong... :(', 3000);
     }
     setDeleteModalOpen(false);
     setEncounterModalOpen(false);

--- a/forgettable-frontend/src/pages/PersonPage/PersonPage.js
+++ b/forgettable-frontend/src/pages/PersonPage/PersonPage.js
@@ -166,7 +166,7 @@ const PersonPage = (props) => {
         birthday={person.birthday}
         socialMedias={person.socialMedia}
         data-testid="drawer-component"
-        onEdit={() => navigate(`edit`)}
+        onEdit={() => navigate(`/people/${id}/edit`)}
       />
       <div className={classes.ContentContainer}>
         <div className={classes.TitleContainer} >

--- a/forgettable-frontend/src/pages/PersonPage/PersonPage.js
+++ b/forgettable-frontend/src/pages/PersonPage/PersonPage.js
@@ -13,6 +13,7 @@ import CustomModal from '../../components/CustomModal/CustomModal';
 import {ToastContainer, toast} from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import {convertSocialMedia} from '../../functions/convertSocialMediaFormat';
+import {toastGenerator} from '../../functions/helper';
 
 /*
  * This is the detailed person profile page. Displays the information
@@ -103,25 +104,9 @@ const PersonPage = (props) => {
         encounters: person.encounters.filter((e) => e._id !== encounter._id),
       });
 
-      toast.success('Encounter deleted!', {
-        position: 'bottom-center',
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      });
+      toastGenerator('success', 'Encounter deleted!', 3000);
     } else {
-      toast.error('Something went wrong... :(', {
-        position: 'bottom-center',
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      });
+      toastGenerator('error', 'Something went wrong... :(', 3000);
     }
 
     setDeleteModalOpen(false);

--- a/forgettable-frontend/src/pages/PersonsListPage/PersonsListPage.js
+++ b/forgettable-frontend/src/pages/PersonsListPage/PersonsListPage.js
@@ -60,25 +60,9 @@ export default function PersonsListPage(props) {
       const newPersonsList = personList.filter((p) => p._id !== id);
       setPersonList(newPersonsList);
 
-      toast.success('Person deleted!', {
-        position: 'bottom-center',
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      });
+      toastGenerator('success', 'Person deleted!', 3000);
     } else {
-      toast.error('Something went wrong... :(', {
-        position: 'bottom-center',
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      });
+      toastGenerator('error', 'Something went wrong... :(', 3000);
     }
 
     setDeleteModalOpen(false);

--- a/forgettable-frontend/src/pages/PersonsListPage/PersonsListPage.js
+++ b/forgettable-frontend/src/pages/PersonsListPage/PersonsListPage.js
@@ -12,6 +12,7 @@ import {useNavigate} from 'react-router-dom';
 import CustomModal from '../../components/CustomModal/CustomModal';
 import {ToastContainer, toast} from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import {toastGenerator} from '../../functions/helper';
 
 const PAGE_SIZE = 10;
 

--- a/forgettable-frontend/src/pages/PersonsListPage/PersonsListPage.js
+++ b/forgettable-frontend/src/pages/PersonsListPage/PersonsListPage.js
@@ -51,7 +51,7 @@ export default function PersonsListPage(props) {
 
   const onEditPersonCardClicked = (event, id) => {
     event.stopPropagation();
-    navigate(`/person/${id}/edit`);
+    navigate(`/people/${id}/edit`);
   };
 
   const onConfirmDeletePerson = async (id) => {

--- a/forgettable-frontend/src/pages/edit/EditPerson.js
+++ b/forgettable-frontend/src/pages/edit/EditPerson.js
@@ -13,60 +13,54 @@ import InputField from '../../components/InputField/InputField';
 const MAX_IMAGE_SIZE = 16000000;
 
 export default function EditPerson() {
-  // to check if it is create person or edit person route
   const location = useLocation();
 
   const navigate = useNavigate();
 
+  // to check if it is create person or edit person route
   const create = location.pathname.includes('/people/create') ? true : false;
 
   const {id} = (!create) && useParams();
 
   const [personData, setPersonData] = useState({
-    first_name: 'Name',
-    last_name: 'Last',
-    birthday: '2012-03-04',
-    gender: 'male',
-    location: 'here',
-    first_met: '2001-01-01',
-    how_we_met: 'idk',
-    interests: 'a',
-    organisation: 'job co.',
-    social_media: new Map([['twitter', 'fdfd']]),
-    image: 'iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAI2SURBVHhe7dpBcgFBFIdxspqlJTtu4hhuwC0cgx23MMexdAPLyavqri6FZOYfyWuv8v0WySBJma9aT6cZd103wjAf+TsGIJaAWAJiCYglIJaAWAJiCYglIJaAWAJiCYglIJaAWAJiCYglIJaAWAJiCYglIJaAWAJiCf5LrLZtF4vF+IHdeTwe8w/16iI7nU7L5fJwOOTbN+yh+XyeT/JbTdPk3+kTO9Z0OrWztQGSTvtnNptN/nN9gsUaPl6eGt7lqQCxXgn0Yp077xtLavS7Ub7yprGs1GQyySUelDT5ttdl6k1jPY6pp2MnP+YV603XWev1Oh2URrvdLt1TUexP/pVFg89Z8O+OgFgCYgmIJQgcq23bfOQl8NVwNptdLpd0zNWwRylla7F08NcCjyznRZZhghdEjeU/u5uoL0P/2d1EHVn+s7uJOrL8Z3fDBC8IGWu/3+cjZzaMw0nvgJnVapXvchFyzioT1vV6bZomHTuIHcv5ycebszyXo/efkAg3sjyXo1bqfD7nGxFHludytLzJlMQbWfZqSAf+z5xFqSBYrCqbDUWwl2GVzYYi2MiqstlQBBtZFWd3wwQvIJaAWAJiCSLFqrbnV9hlJYpae35FpKVDWTc47/kVIWPVes5M8AJiCYgliBSryqR+K1Ks7XZrX6vsNyTxtpUrYs4SEEtALAGxBMQSEEtALAGxBMQSEEtALAGxBMQSEEtALAGxBMQSEEtALAGxBMQSEEtALAGxBhuNPgHlJKV46HCjogAAAABJRU5ErkJggg==',
+    first_name: '',
+    last_name: '',
+    birthday: '',
+    gender: '',
+    location: '',
+    first_met: '',
+    how_we_met: '',
+    interests: [],
+    organisation: '',
+    social_media: new Map(),
+    image: '',
     encounters: [],
-    time_updated: '0002-02-02',
+    time_updated: '',
   });
 
-  // const [personData, setPersonData] = useState({
-  //   first_name: '',
-  //   last_name: '',
-  //   birthday: null,
-  //   gender: '',
-  //   location: '',
-  //   first_met: null,
-  //   how_we_met: '',
-  //   interests: '',
-  //   organisation: '',
-  //   social_media: new Map(),
-  //   image: '',
-  //   encounters: [],
-  //   time_updated: '',
-  // });
 
   function handleUpdateData(newData) {
     setPersonData(newData);
   }
 
-  (!create) && (
-    useEffect(async () => {
-      try {
-        receivedData = await apiCalls.getPerson(id);
-        handleUpdateData(receivedData);
-      } catch (err) {
-        console.log(err);
-      }
-    }, [id]));
+  (!create) && (useEffect(async () => {
+    const result = await apiCalls.getPerson(id);
+    setPersonData({
+      first_name: result.first_name,
+      last_name: result.last_name || '',
+      birthday: getInputDateFormatString(result.birthday),
+      first_met: getInputDateFormatString(result.first_met),
+      gender: result.gender || '',
+      location: result.location || '',
+      how_we_met: result.how_we_met || '',
+      interests: result.interests || '',
+      organisation: result.organisation || '',
+      social_media: new Map(convertSocialMedia(result.socialMedia)),
+      img: result.image,
+      encounters: result.encounters || [],
+      time_updated: result.time_updated,
+    });
+  }, [id]));
 
   let initialProfilePic = '';
   let initialProfilePicPreview = '';
@@ -77,11 +71,9 @@ export default function EditPerson() {
       initialProfilePicPreview = 'data:image/*;base64,' + personData.image);
   }
 
-
   const [profilePicPreview, setProfilePicPreview] = useState(initialProfilePicPreview);
   const [profilePic, setProfilePic] = useState(initialProfilePic);
 
-  // use data from object from API
   const [socialMedias, setSocialMedias] = useState((create) ? (new Map()) : personData.social_media);
 
   const [socialMediaModalOpen, setSocialMediaModalOpen] = useState(false);

--- a/forgettable-frontend/src/pages/edit/EditPerson.js
+++ b/forgettable-frontend/src/pages/edit/EditPerson.js
@@ -13,6 +13,7 @@ import {convertSocialMedia} from '../../functions/convertSocialMediaFormat';
 import {getInputDateFormatString, getLongDateStringWithSlashes} from '../../functions/dateFormatter';
 import {ToastContainer, toast} from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import {toastGenerator} from '../../functions/helper';
 
 const MAX_IMAGE_SIZE = 16000000;
 
@@ -127,45 +128,19 @@ export default function EditPerson() {
       );
       setProfilePicPreview(imageURL);
     } else {
-      toast.error('Image too big, must be less than 16mb', {
-        position: 'bottom-center',
-        autoClose: 2000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      });
-      console.log('Image too big, must be less than 16mb');
+      toastGenerator('error', 'Image too big, must be less than 16mb', 2000);
     }
   }
 
   const onDeleteConfirmed = async (id) => {
     const result = await apiCalls.deletePerson(id);
-
     if (result) {
-      toast.success('Person deleted!', {
-        position: 'bottom-center',
-        autoClose: 2000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      });
+      toastGenerator('success', 'Person deleted!', 2000);
       setTimeout(()=> {
         navigate('/people');
       }, 2000);
     } else {
-      toast.error('Something went wrong... :(', {
-        position: 'bottom-center',
-        autoClose: 2000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-      });
+      toastGenerator('error', 'Something went wrong... :(', 2000);
     }
     setDeleteModalOpen(false);
   };
@@ -185,54 +160,22 @@ export default function EditPerson() {
       if (create) {
         const result = await apiCalls.createPerson(data);
         if (result) {
-          toast.success('Person Created!', {
-            position: 'bottom-center',
-            autoClose: 2000,
-            hideProgressBar: false,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-          });
+          toastGenerator('success', 'Person Created!', 2000);
           setTimeout(()=> {
             navigate('/encounters/create');
-          }, 3000);
+          }, 2000);
         } else {
-          toast.error('Something went wrong... :(', {
-            position: 'bottom-center',
-            autoClose: 2000,
-            hideProgressBar: false,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-          });
+          toastGenerator('error', 'Something went wrong... :(', 2000);
         }
       } else {
         const result = await apiCalls.updatePerson(id, data);
         if (result == '') {
-          toast.success('Person Saved!', {
-            position: 'bottom-center',
-            autoClose: 2000,
-            hideProgressBar: false,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-          });
+          toastGenerator('success', 'Person Saved!', 2000);
           setTimeout(()=> {
             navigate(`/person/${id}`);
-          }, 3000);
+          }, 2000);
         } else {
-          toast.error('Something went wrong... :(', {
-            position: 'bottom-center',
-            autoClose: 2000,
-            hideProgressBar: false,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-          });
+          toastGenerator('error', 'Something went wrong... :(', 2000);
         }
       }
     }, 1000);

--- a/forgettable-frontend/src/pages/edit/EditPerson.js
+++ b/forgettable-frontend/src/pages/edit/EditPerson.js
@@ -244,18 +244,16 @@ export default function EditPerson() {
       <form onSubmit={handleSubmit} className={classes.form}>
         <div className={classes.avatarDiv}>
           <Avatar src={profilePicPreview} className={classes.avatar}></Avatar>
-          <label htmlFor='inputProfilePic'>
-            <CustomButton
-              btnText="Change"
-              className={classes.avatarButton}
-              onChange={() => inputProfilePic.current.click()} />
+          <label className={classes.changeImgButtonWrapper}>
+            Change
+            <Input
+              id='inputProfilePic'
+              type='file'
+              accept='image/*'
+              className={classes.changeImgButton}
+              onChange={uploadImagePreview}
+            />
           </label>
-          <Input
-            id='inputProfilePic'
-            type="file"
-            accept="image/*"
-            onChange={uploadImagePreview}
-            className={classes.profilePicUpload} />
         </div>
 
         <div className={classes.row}>

--- a/forgettable-frontend/src/pages/edit/EditPerson.module.css
+++ b/forgettable-frontend/src/pages/edit/EditPerson.module.css
@@ -126,4 +126,21 @@
 
 .formsButton {
     margin-right: 20px;
+.DeleteModal {
+    width: 400px;
+    display: flex;
+    flex-direction: column ;
+    align-items: center;
+}
+
+.DeleteModal > h1 {
+    color: #E05A33;
+    font-size: var(--text-xxlarge);
+    text-align: center;
+    font-weight: 600;
+}
+
+.DeleteModal > p {
+    text-align: center;
+    font-size: var(--text-large);
 }

--- a/forgettable-frontend/src/pages/edit/EditPerson.module.css
+++ b/forgettable-frontend/src/pages/edit/EditPerson.module.css
@@ -14,14 +14,16 @@
 }
 
 .form {
-    margin-top: 32px;
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
 }
 
 .column {
     padding-right: 40px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 20px;
 }
 
 .row {
@@ -41,6 +43,7 @@
 .avatar {
     width: 120px !important;
     height: 120px !important;
+    border: 1.5px solid var(--bord);
 }
 
 .profilePicUpload {
@@ -51,6 +54,7 @@
     display: flex;
     flex-wrap: wrap;
     width: inherit;
+    gap: 3px;
     margin-bottom: 20px;
 }
 
@@ -65,6 +69,8 @@
     height: 50px;
     font-size: xx-large;
     background-color: var(--bkgd);
+    border: 1.5px solid var(--bord);
+    color: var(--bord);
     border-style: solid;
     cursor: pointer;
 }
@@ -113,7 +119,9 @@
 .formButtonsDiv {
     display: flex;
     float: right;
-    margin-top: 20px;
+    margin-top: 10px;
+    align-self: flex-end;
+    padding-right: 40px;
 }
 
 .formsButton {

--- a/forgettable-frontend/src/pages/edit/EditPerson.module.css
+++ b/forgettable-frontend/src/pages/edit/EditPerson.module.css
@@ -126,6 +126,34 @@
 
 .formsButton {
     margin-right: 20px;
+}
+
+.changeImgButton {
+    color: transparent;
+    width: 0px;
+    visibility: hidden;
+}
+
+.changeImgButtonWrapper{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border:2px solid black;
+    border-radius: var(--radius-btn);
+    padding: 3px 12px 3px 12px;
+    box-sizing: border-box;
+    width: fit-content;
+    margin-left: 20px;
+    cursor: pointer;
+    font-size: var(--text-normal);
+    user-select: none;
+    background-color: var(--bkgd);
+}
+
+.changeImgButtonWrapper:hover{
+    background-color: var(--hilit);
+}
+
 .DeleteModal {
     width: 400px;
     display: flex;


### PR DESCRIPTION
- Fixed styling to match the style guide
- Fixed API calls to get data from the backend
- Fixed submit logic, covers both create and edit page, can now successfully POST or PUT a person and update database
- Fixed delete handling logic, update modal, can now successfully DELETE a person and update database
- Fixed change image button, now can fire up selecting file screen and selecting an image can update the avatar preview (might need to merge Hazel's pr to continue, and currently still have some issue when submitting the image to backend)
- Added placeholders for each input field
- Fixed input field, now can handle live updating
- Added type to button so not all buttons trigger the submit action
- Fixed routing on Person and PersonsList page to go to '/people/:id/edit' when clicking on the edit button (it was '/person/:id/edit)
- Added a toast generator helper function to replace duplicated code, updated all files used toast

Fixes most of #271 

**Demo:**
![Screen Shot 2022-03-19 at 11 13 15 PM](https://user-images.githubusercontent.com/37087904/159116998-908d3896-77b4-4f40-8ecb-af3cecedeb8b.png)

