### PR TITLE
Fix loop logic in get persons endpoint controller

### DIFF
--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -80,7 +80,7 @@ export const getPersonWithId = async (
           await Promise.all(personDto.encounters.map(
             async (encounterId: any) => { return (await encounterService.getEncounter(encounterId)) }))));
 
-        for (let i = 0; i < personDto.encounters.length; i + 1) {
+        for (let i = 0; i < personDto.encounters.length; i++) {
           personDto.encounters[i].persons = await Promise.all(personDto.encounters[i].persons.map(
             async (personsId: any) => { return (await getPersonDetails(personsId)); }));
         }


### PR DESCRIPTION
Addresses #288 

Fixed for loop which fetches `person` details in `getPersonWithId()`. Had an issue with the iteration logic where `i++` was replaced with `i+1` due to a auto formatting change.