### PR TITLE
Handle overflow of strings in smaller components

### DIFF
--- a/forgettable-frontend/src/components/EncounterCard/EncounterCard.js
+++ b/forgettable-frontend/src/components/EncounterCard/EncounterCard.js
@@ -61,7 +61,7 @@ const EncounterCard = (props) => {
             </div>
           </div>
           <div className={classes.Location}>
-            {WHERE_WE_MET}<div>{location ? location : <UnknownDetail/>}</div>
+            {WHERE_WE_MET}<span>{location ? location : <UnknownDetail/>}</span>
           </div>
           <CustomButton btnText={DELETE} onClick={handleOnDelete}/>
         </section>

--- a/forgettable-frontend/src/components/EncounterCard/EncounterCard.module.css
+++ b/forgettable-frontend/src/components/EncounterCard/EncounterCard.module.css
@@ -96,6 +96,13 @@
     font-size: var(--text-small);
     font-weight: var(--font-regular);
     color: var(--txt2);
+    max-width: 40%;
+    white-space: nowrap;
+}
+
+.Location > span {
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .Avatar{

--- a/forgettable-frontend/src/components/EncounterCardSummary/EncounterCardSummary.module.css
+++ b/forgettable-frontend/src/components/EncounterCardSummary/EncounterCardSummary.module.css
@@ -86,3 +86,10 @@
             line-clamp: 3; 
     -webkit-box-orient: vertical;
 }
+
+.IdentityInfoConatiner > h3 {
+    text-align: left;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 110px;
+}

--- a/forgettable-frontend/src/components/PersonCard/PersonCard.js
+++ b/forgettable-frontend/src/components/PersonCard/PersonCard.js
@@ -144,7 +144,8 @@ const PersonCard = (props) => {
               >
                 Date last met: {
                 props.lastMet ?
-                getLongDateStringWithSlashes(props.lastMet) : <UnknownDetail/>}
+                <span>getLongDateStringWithSlashes(props.lastMet)</span> :
+                 <UnknownDetail/>}
               </p>
               <div className={classes.SocialMediaContainer}>
                 <AvatarGroup max={2}

--- a/forgettable-frontend/src/components/PersonCard/PersonCard.module.css
+++ b/forgettable-frontend/src/components/PersonCard/PersonCard.module.css
@@ -88,3 +88,20 @@
     align-self: flex-start;
 }
 
+.LastMet {
+    max-width: 40%;
+    display: flex;
+    flex-direction: row;
+    white-space: nowrap;
+}
+
+.LastMet > span {
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 1; /* number of lines to show */
+            line-clamp: 1; 
+    -webkit-box-orient: vertical;
+    margin-left: 3px;
+}

--- a/forgettable-frontend/src/components/PersonCardSummary/PersonCardSummary.module.css
+++ b/forgettable-frontend/src/components/PersonCardSummary/PersonCardSummary.module.css
@@ -49,6 +49,7 @@
     -webkit-line-clamp: 1; /* number of lines to show */
             line-clamp: 1; 
     -webkit-box-orient: vertical;
+    max-width: 110px;
 }
 
 .TextInfoContainer > p {


### PR DESCRIPTION
* Added line clamps/ellipsises to all small space text to make sure it doesn't overflow weirdly

Fixes #302 