### PR TITLE
Update time_updated in encounter and person put endpoints

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -16,6 +16,10 @@
         "@typescript-eslint"
     ],
     "rules": {
+        "linebreak-style": [
+            "error",
+            "windows"
+        ],
         "import/no-unresolved": "off",
         "import/extensions": "off",
         "consistent-return": "off",

--- a/backend/src/controllers/encounter.controller.ts
+++ b/backend/src/controllers/encounter.controller.ts
@@ -103,6 +103,8 @@ export const updateEncounter = async (
 
     // update encounter
     const newEncounterData = getEncounterFromReqBody(req.body);
+    // update time_updated to the present time
+    newEncounterData.time_updated = new Date(Date.now());
     const updatedEncounter = await encounterService.updateEncounter(
       encounterIdToUpdate,
       newEncounterData,

--- a/backend/src/controllers/person.controller.ts
+++ b/backend/src/controllers/person.controller.ts
@@ -197,6 +197,8 @@ export const updatePersonWithId = async (
       return res.status(httpStatus.UNAUTHORIZED).end();
     }
     const newPersonData: PersonModel = req.body;
+    // update time_updated to the present time
+    newPersonData.time_updated = new Date(Date.now());
     let updatedPerson: any;
     // If the person belongs to this user, find it and update
     if (user.persons.includes(new mongoose.Types.ObjectId(req.params.id))) {


### PR DESCRIPTION
In relation to issue (#323)

When calling those put endpoints, the time_updated will be updated and set to the current time.