### PR TITLE
Disallow future dates for encounters

### DIFF
--- a/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
+++ b/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
@@ -13,17 +13,18 @@ import Loading from '../Loading/Loading';
 
 export default function CreateEncountersPage() {
   const navigate = useNavigate();
+  const currentDateString = new Date().toLocaleDateString('en-CA');
+
   const [optionsList, setOptionsList] = React.useState([]);
   const [encounter, setEncounter] = React.useState({
     title: '',
-    date: null,
-    location: null,
+    date: currentDateString,
+    location: '',
     description: '',
     persons: [],
   });
   const [isSubmittable, setIsSubmittable] = React.useState(false);
   const [showWarning, setShowWarning] = React.useState(false);
-
   const [loading, setLoading] = useState(false);
 
   async function getData() {
@@ -79,7 +80,10 @@ export default function CreateEncountersPage() {
   };
 
   const handleSaveClick = async (event) => {
-    if (!encounter.title || encounter.persons.length === 0 || !encounter.description) {
+    const currentDate = new Date(currentDateString).getTime();
+    const encounterDate = new Date(encounter.date).getTime();
+
+    if (!encounter.title || encounter.persons.length === 0 || !encounter.description || encounterDate > currentDate) {
       setShowWarning(true);
     } else {
       setShowWarning(false);
@@ -209,7 +213,7 @@ export default function CreateEncountersPage() {
           </div>
 
           <div className={classes.WarningText}>
-            {showWarning && 'Encounters must have a title, a description and at least one person'}
+            {showWarning && 'Encounters must have a title, a description, at least one person and must not take place in the future'}
           </div>
 
         </div>

--- a/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
+++ b/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
@@ -13,6 +13,8 @@ import Loading from '../Loading/Loading';
 
 export default function CreateEncountersPage() {
   const navigate = useNavigate();
+
+  // the en-CA locale uses yyyy-mm-dd formatting which is required for the max date
   const currentDateString = new Date().toLocaleDateString('en-CA');
 
   const [optionsList, setOptionsList] = React.useState([]);
@@ -163,8 +165,7 @@ export default function CreateEncountersPage() {
             <div className={classes.Text}>Date we met:</div>
             <input className={classes.DateInput}
               type='date'
-              // the en-CA locale uses yyyy-mm-dd formatting which is required for the max date
-              max={new Date().toLocaleDateString('en-CA')}
+              max={currentDateString}
               name='date_met'
               value={encounter.date}
               onChange={handleDateChange}

--- a/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
+++ b/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
@@ -159,6 +159,8 @@ export default function CreateEncountersPage() {
             <div className={classes.Text}>Date we met:</div>
             <input className={classes.DateInput}
               type='date'
+              // the en-CA locale uses yyyy-mm-dd formatting which is required for the max date
+              max={new Date().toLocaleDateString('en-CA')}
               name='date_met'
               value={encounter.date}
               onChange={handleDateChange}


### PR DESCRIPTION
Closes #286 

A max tag is added to the HTML5 date input which stops the user from being able to pick future dates
![image](https://user-images.githubusercontent.com/54062686/160504617-a98c0a37-19c0-483b-86f7-f576b10a3125.png)

If they manually type a future date, they will get this error on submit
![image](https://user-images.githubusercontent.com/54062686/160504600-668a9dbb-b75d-4a64-bc57-a4cfa68b1467.png)

Also, null was being passed as a default value to the date picker which is not allowed, so I changed it to use the current date as default instead.
