### PR TITLE
Add location autocomplete to encounters page

### DIFF
--- a/forgettable-frontend/.gitignore
+++ b/forgettable-frontend/.gitignore
@@ -28,3 +28,10 @@ yarn-error.log*
 
 # Firebase Config
 /src/firebase-config.js
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local

--- a/forgettable-frontend/package.json
+++ b/forgettable-frontend/package.json
@@ -16,6 +16,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-firebase-hooks": "^5.0.3",
+    "react-google-autocomplete": "^2.6.1",
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^6.2.2",
     "react-scripts": "^5.0.0",

--- a/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.js
+++ b/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.js
@@ -1,52 +1,28 @@
-import React, {useState, useEffect, useRef} from 'react';
+import React, {useState, useEffect} from 'react';
 import classes from './AutocompleteLocationInput.module.css';
-
 import Autocomplete, {usePlacesWidget} from 'react-google-autocomplete';
 
-// Code adapted from:
-// https://betterprogramming.pub/the-best-practice-with-google-place-autocomplete-api-on-react-939211e8b4ce
-// and https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete
-
 export default function AutocompleteLocationInput(props) {
-  const placeName = useRef('');
+  const [placename, setPlacename] = useState('');
   
-  const [country, setCountry] = useState('nz');
   const {ref: ref} = usePlacesWidget({
     apiKey: process.env.REACT_APP_MAPS_API_KEY,
-    onPlaceSelected: (place) => {
-      console.log('place:')
-      console.log(place);
-      console.log('checking if same')
-      if (!(placeName.current == place.name)) {
-        console.log('wasnt the same')
-        placeName.current = place.name;
-      }
-    },
-
-    // inputAutocompleteValue: 'country',
     options: {
-      componentRestrictions: {country},
+      types: ['establishment'],
       fields: ['name'],
     },
+    onPlaceSelected: (place) => {setPlacename(place.name);},
   });
 
   useEffect(() => {
-    console.log('useEffect');
-    console.log(placeName)
-    debugger;
-    props.handleChange(placeName);
-  }, []);
-
+    props.handleChange(placename);
+  }, [placename]);
 
   return (
     <input className={classes.InputBox}
       size='small'
       ref={ref}
-      onChange={(event) => {
-        console.log('change');
-      }}
-
-      placeholder='Enter a Location'
+      placeholder='Location'
     />
   );
 }

--- a/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.js
+++ b/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.js
@@ -1,0 +1,52 @@
+import React, {useState, useEffect, useRef} from 'react';
+import classes from './AutocompleteLocationInput.module.css';
+
+import Autocomplete, {usePlacesWidget} from 'react-google-autocomplete';
+
+// Code adapted from:
+// https://betterprogramming.pub/the-best-practice-with-google-place-autocomplete-api-on-react-939211e8b4ce
+// and https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete
+
+export default function AutocompleteLocationInput(props) {
+  const placeName = useRef('');
+  
+  const [country, setCountry] = useState('nz');
+  const {ref: ref} = usePlacesWidget({
+    apiKey: process.env.REACT_APP_MAPS_API_KEY,
+    onPlaceSelected: (place) => {
+      console.log('place:')
+      console.log(place);
+      console.log('checking if same')
+      if (!(placeName.current == place.name)) {
+        console.log('wasnt the same')
+        placeName.current = place.name;
+      }
+    },
+
+    // inputAutocompleteValue: 'country',
+    options: {
+      componentRestrictions: {country},
+      fields: ['name'],
+    },
+  });
+
+  useEffect(() => {
+    console.log('useEffect');
+    console.log(placeName)
+    debugger;
+    props.handleChange(placeName);
+  }, []);
+
+
+  return (
+    <input className={classes.InputBox}
+      size='small'
+      ref={ref}
+      onChange={(event) => {
+        console.log('change');
+      }}
+
+      placeholder='Enter a Location'
+    />
+  );
+}

--- a/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.js
+++ b/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.js
@@ -1,10 +1,10 @@
 import React, {useState, useEffect} from 'react';
 import classes from './AutocompleteLocationInput.module.css';
-import Autocomplete, {usePlacesWidget} from 'react-google-autocomplete';
+import {usePlacesWidget} from 'react-google-autocomplete';
 
 export default function AutocompleteLocationInput(props) {
   const [placename, setPlacename] = useState('');
-  
+
   const {ref: ref} = usePlacesWidget({
     apiKey: process.env.REACT_APP_MAPS_API_KEY,
     options: {
@@ -12,7 +12,9 @@ export default function AutocompleteLocationInput(props) {
       types: ['establishment'],
       fields: ['name'],
     },
-    onPlaceSelected: (place) => {setPlacename(place.name);},
+    onPlaceSelected: (place) => {
+      setPlacename(place.name);
+    },
   });
 
   useEffect(() => {

--- a/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.js
+++ b/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.js
@@ -8,6 +8,7 @@ export default function AutocompleteLocationInput(props) {
   const {ref: ref} = usePlacesWidget({
     apiKey: process.env.REACT_APP_MAPS_API_KEY,
     options: {
+      componentRestrictions: {country: 'nz'},
       types: ['establishment'],
       fields: ['name'],
     },

--- a/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.module.css
+++ b/forgettable-frontend/src/components/AutocompleteLocationInput/AutocompleteLocationInput.module.css
@@ -1,0 +1,14 @@
+@import '../../colours.css';
+
+/* The Google Maps Autocomplete is incompatible with the MUI TextField used by the other components, so this styling emulates that. */
+.InputBox{
+    width: 100%;
+    background-color: white;
+    color: rgba(0, 0, 0, 0.87);
+    border-radius: 4px;
+    padding: 8.5px;
+    font-size: 16px;
+    height: 23px;
+    border: 1px solid var(--bord);
+    font-family: "Roboto", "Helvetica", "Arial", sans-serif
+}

--- a/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
+++ b/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
@@ -10,6 +10,7 @@ import {Link, useNavigate} from 'react-router-dom';
 import {toastGenerator} from '../../functions/helper';
 import {ToastContainer} from 'react-toastify';
 import Loading from '../Loading/Loading';
+import AutocompleteLocationInput from '../../components/AutocompleteLocationInput/AutocompleteLocationInput';
 
 export default function CreateEncountersPage() {
   const navigate = useNavigate();
@@ -71,8 +72,12 @@ export default function CreateEncountersPage() {
     setEncounter({...encounter, title: event.target.value});
   };
 
-  const handleLocationChange=(event)=>{
-    setEncounter({...encounter, location: event.target.value});
+  const handleLocationChange=(placeName)=>{
+    console.log('placeName:');
+    console.log(placeName);
+    setEncounter({...encounter, location: placeName});
+    console.log('encounter:');
+    console.log(encounter);
   };
   const handleDescriptionChange=(event)=>{
     setEncounter({...encounter, description: event.target.value});
@@ -168,16 +173,7 @@ export default function CreateEncountersPage() {
 
           <div className={classes.TextField}>
             <div className={classes.Text}>Where we met:</div>
-            <div className={classes.InputBox}>
-              <TextField
-                size='small'
-                id="fullWidth"
-                sx={{width: 1/1}}
-                color='info'
-                value={encounter.location}
-                onChange={handleLocationChange}
-              />
-            </div>
+            <AutocompleteLocationInput handleChange={handleLocationChange} className={classes.InputBox}/>
           </div>
 
           <div>

--- a/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
+++ b/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
@@ -76,7 +76,7 @@ export default function CreateEncountersPage() {
   const handleLocationChange=(placename)=>{
     setEncounter({...encounter, location: placename});
   };
-  
+
   const handleDescriptionChange=(event)=>{
     setEncounter({...encounter, description: event.target.value});
   };

--- a/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
+++ b/forgettable-frontend/src/pages/CreateEncounterPage/CreateEncounterPage.js
@@ -72,13 +72,11 @@ export default function CreateEncountersPage() {
     setEncounter({...encounter, title: event.target.value});
   };
 
-  const handleLocationChange=(placeName)=>{
-    console.log('placeName:');
-    console.log(placeName);
-    setEncounter({...encounter, location: placeName});
-    console.log('encounter:');
-    console.log(encounter);
+  // Doesn't use an event as it's called by passing in as a prop to AutocompleteLocationInput
+  const handleLocationChange=(placename)=>{
+    setEncounter({...encounter, location: placename});
   };
+  
   const handleDescriptionChange=(event)=>{
     setEncounter({...encounter, description: event.target.value});
   };


### PR DESCRIPTION
Add a location autocomplete to the create encounters page, powered by the Google Maps API.

Requires creating a file named `.env` within `forgettable-frontend/` with the Google Maps API key in it. See #next-repo channel on discord for details.

No tests added.

![image](https://user-images.githubusercontent.com/68830694/160505318-8fb8fbfa-4f68-4fac-9025-b2a74c5b1c7e.png)

![image](https://user-images.githubusercontent.com/68830694/160505404-8e262a99-4034-4443-992f-abdabb8f9b05.png)

Closes #250 
