### PR TITLE
[#234] Encounter Time Modified Pruning Settings - Frontend

### DIFF
--- a/forgettable-frontend/src/pages/SettingsPage/SettingsPage.js
+++ b/forgettable-frontend/src/pages/SettingsPage/SettingsPage.js
@@ -1,10 +1,24 @@
-import React, {useContext} from 'react';
+/* eslint-disable max-len */
+import React, {useContext, useState} from 'react';
 import classes from './SettingsPage.module.css';
 import DarkMode from './DarkMode';
 import CustomButton from '../../components/CustomButton/CustomButton';
 import {AuthContext} from '../../context/AuthContext';
+import {pruneEncounters} from '../../services';
+import styles from '../../components/InputField/InputField.module.css';
+import {toastGenerator} from '../../functions/helper';
 
 function SettingsPage() {
+  // eslint-disable-next-line prefer-const
+  // the en-CA locale uses yyyy-mm-dd formatting which is required for the max date
+  const currentDateString = new Date().toLocaleDateString('en-CA');
+  const [pruneDate, setPruneDate] = useState();
+
+  // Handler for updating date state in prune settings
+  const handleDateChange = (event) => {
+    setPruneDate(event.target.value);
+  };
+
   const authContext = useContext(AuthContext);
 
   return (
@@ -28,6 +42,23 @@ function SettingsPage() {
           onClick={authContext.logout}
         />
         <h2>
+          Manage Data
+        </h2>
+        <div>
+          <div className={classes.DetailSet}> <h4>Prune data before this date:</h4></div>
+          <input className={styles.inputFieldPrimary}
+            type='date'
+            max={currentDateString}
+            name='prune_date'
+            onChange={handleDateChange}
+          />
+          <CustomButton
+            btnText="Confirm"
+            className={classes.PruneButton}
+            onClick={() => handlePruneButton(pruneDate)}
+          />
+        </div>
+        <h2>
           Appearance
         </h2>
         <div className={classes.DarkModeContainer}>
@@ -40,5 +71,22 @@ function SettingsPage() {
     </div>
   );
 }
+
+/**
+ * Deals with sending the request to prune endpoint and popping up the response alert
+ * @param {*} pruneDate Input date to prune from, taken from Date input
+ */
+const handlePruneButton = async (pruneDate) => {
+  const result = await pruneEncounters(pruneDate);
+  if (result) {
+    toastGenerator('success', 'Encounters Pruned!', 2000);
+    setTimeout(() => {
+      navigate('/encounters', {state: {person: result}});
+    }, 1000);
+  } else {
+    toastGenerator('error', 'Something went wrong... :(', 2000);
+    setLoading(false);
+  }
+};
 
 export default SettingsPage;

--- a/forgettable-frontend/src/pages/SettingsPage/SettingsPage.module.css
+++ b/forgettable-frontend/src/pages/SettingsPage/SettingsPage.module.css
@@ -55,6 +55,12 @@
   height: 40px;
 }
 
+.PruneButton {
+  margin-top: 10px;
+  font-size: var(--text-small);
+  height: 40px;
+}
+
 .DarkModeContainer {
   display: flex;
   flex-direction: row;

--- a/forgettable-frontend/src/services/index.js
+++ b/forgettable-frontend/src/services/index.js
@@ -84,6 +84,16 @@ export const getAllEncounters = async () => {
 };
 
 /**
+ * Deletes all Encounters for the logged in user where the
+ * time_updated field precedes pruneDate
+ * @param {*} pruneDate Prune all encounters last modified before this date
+ * @return {Promise}
+ */
+export const pruneEncounters = async (pruneDate) => {
+  return await deleteData('encounters/prune/' + pruneDate);
+};
+
+/**
  * Fetches Encounters entries with pagination
  * @param {string} page starting page (starting index = 1)
  * @param {string} limit how many entries on one page


### PR DESCRIPTION
- Added 'Manage Data' section to Settings page which contains pruning settings
- Has date selector and Prune button
- Popup upon confirming Prune to notify user of response
![image](https://user-images.githubusercontent.com/61653096/161417010-cf42243c-8eba-4c62-be60-aa26379007ed.png)
- Added pruneEncounters method to index.js, which calls the Prune endpoint created for the backend of this issue